### PR TITLE
Add Claude debugger configuration for Storybook

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "storybook",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "storybook"],
+      "port": 6006,
+      "autoPort": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Added a debugger configuration file for Claude to enable debugging of the Storybook development server.

## Changes
- Added `.claude/launch.json` with a debug configuration for running Storybook
  - Configured to launch Storybook via `npm run storybook`
  - Set to use port 6006 with auto-port assignment enabled
  - Allows developers to debug Storybook components directly within Claude

## Details
This configuration enables seamless debugging of Storybook in the Claude environment by specifying the runtime executable (npm), the command arguments to start Storybook, and the port configuration for the development server.