### PR TITLE
fix(use-calendar): honor min/max in month/year picker screen

### DIFF
--- a/src/elements/use-calendar/use-calendar.test.ts
+++ b/src/elements/use-calendar/use-calendar.test.ts
@@ -410,5 +410,61 @@ describe('use-calendar', () => {
 
       expect(getShadow(calendar).activeElement).toBe(yearBtns[11]); // December
     });
+
+    it('with min set, picker starts from the min year', async () => {
+      render(html`<use-calendar year="2025" month="6" min="2024-03-01"></use-calendar>`);
+      const calendar = getCalendar();
+      await calendar.updateComplete;
+      getTitleButton(calendar).click();
+      await calendar.updateComplete;
+
+      const sections = getShadow(calendar).querySelectorAll('[part="picker-year-section"]');
+      const years = Array.from(sections).map((s) => Number(s.getAttribute('data-picker-year')));
+      expect(years[0]).toBe(2024);
+      expect(years).not.toContain(2023);
+    });
+
+    it('with max set, picker ends at the max year', async () => {
+      render(html`<use-calendar year="2025" month="6" max="2026-09-30"></use-calendar>`);
+      const calendar = getCalendar();
+      await calendar.updateComplete;
+      getTitleButton(calendar).click();
+      await calendar.updateComplete;
+
+      const sections = getShadow(calendar).querySelectorAll('[part="picker-year-section"]');
+      const years = Array.from(sections).map((s) => Number(s.getAttribute('data-picker-year')));
+      expect(years[years.length - 1]).toBe(2026);
+      expect(years).not.toContain(2027);
+    });
+
+    it('months before min in the min year are not rendered in the picker', async () => {
+      render(html`<use-calendar year="2025" month="6" min="2025-04-01"></use-calendar>`);
+      const calendar = getCalendar();
+      await calendar.updateComplete;
+      getTitleButton(calendar).click();
+      await calendar.updateComplete;
+
+      const btns = getYearSectionBtns(calendar, 2025);
+      const monthNums = btns.map((b) => Number(b.getAttribute('data-picker-month')));
+      expect(monthNums).not.toContain(1);
+      expect(monthNums).not.toContain(2);
+      expect(monthNums).not.toContain(3);
+      expect(monthNums).toContain(4);
+    });
+
+    it('months after max in the max year are not rendered in the picker', async () => {
+      render(html`<use-calendar year="2026" month="6" max="2026-09-30"></use-calendar>`);
+      const calendar = getCalendar();
+      await calendar.updateComplete;
+      getTitleButton(calendar).click();
+      await calendar.updateComplete;
+
+      const btns = getYearSectionBtns(calendar, 2026);
+      const monthNums = btns.map((b) => Number(b.getAttribute('data-picker-month')));
+      expect(monthNums).toContain(9);
+      expect(monthNums).not.toContain(10);
+      expect(monthNums).not.toContain(11);
+      expect(monthNums).not.toContain(12);
+    });
   });
 });

--- a/src/elements/use-calendar/use-calendar.ts
+++ b/src/elements/use-calendar/use-calendar.ts
@@ -247,6 +247,12 @@ export class UseCalendar extends LitElement {
     return (this.min && date < this.min) || (this.max && date > this.max);
   }
 
+  #monthAllowed(month: number, year: number) {
+    const firstDay = this.#formatDate(year, month, 1);
+    const lastDay = this.#formatDate(year, month, new Date(year, month, 0).getDate());
+    return (!this.min || lastDay >= this.min) && (!this.max || firstDay <= this.max);
+  }
+
   #internalSetValue(value: string | { isoWeek: string; dates: string[] }) {
     if (typeof value === 'string') {
       if (this.#dateDisabled(value)) return;
@@ -835,9 +841,10 @@ export class UseCalendar extends LitElement {
 
   #renderPicker() {
     const months = getMonthNames(this.locale, 'short');
-    const rows = [months.slice(0, 4), months.slice(4, 8), months.slice(8, 12)];
-    const startYear = 1970;
-    const endYear = new Date().getFullYear() + 100;
+    const startYear = this.min ? (this.#parseDate(this.min)?.getFullYear() ?? 1970) : 1970;
+    const endYear = this.max
+      ? (this.#parseDate(this.max)?.getFullYear() ?? new Date().getFullYear() + 100)
+      : new Date().getFullYear() + 100;
     const years = Array.from({ length: endYear - startYear + 1 }, (_, i) => startYear + i);
     return html`
       <div
@@ -845,37 +852,34 @@ export class UseCalendar extends LitElement {
         id="calendar-picker"
         style=${this.#pickerHeight != null ? `max-height:${this.#pickerHeight}px` : ''}
       >
-        ${years.map(
-          (year) => html`
+        ${years.map((year) => {
+          const allowedMonths = months
+            .map((name, i) => ({ name, monthNum: i + 1 }))
+            .filter(({ monthNum }) => this.#monthAllowed(monthNum, year));
+          return html`
             <div part="picker-year-section" data-picker-year=${year}>
               <div part="picker-year-label">${year}</div>
               <div part="picker-months" role="grid" aria-label=${String(year)}>
-                ${rows.map(
-                  (row, ri) => html`
-                    <div role="row">
-                      ${row.map((name, ci) => {
-                        const monthNum = ri * 4 + ci + 1;
-                        const isCurrent = year === this.year && monthNum === this.month;
-                        return html`
-                          <button
-                            part="picker-month ${isCurrent ? 'picker-month-current' : ''}"
-                            role="gridcell"
-                            type="button"
-                            aria-selected=${isCurrent ? 'true' : 'false'}
-                            tabindex=${isCurrent ? '0' : '-1'}
-                            @click=${() => this.#selectMonth(monthNum, year)}
-                          >
-                            ${name}
-                          </button>
-                        `;
-                      })}
-                    </div>
-                  `
-                )}
+                ${allowedMonths.map(({ name, monthNum }) => {
+                  const isCurrent = year === this.year && monthNum === this.month;
+                  return html`
+                    <button
+                      part="picker-month ${isCurrent ? 'picker-month-current' : ''}"
+                      role="gridcell"
+                      type="button"
+                      aria-selected=${isCurrent ? 'true' : 'false'}
+                      tabindex=${isCurrent ? '0' : '-1'}
+                      data-picker-month=${monthNum}
+                      @click=${() => this.#selectMonth(monthNum, year)}
+                    >
+                      ${name}
+                    </button>
+                  `;
+                })}
               </div>
             </div>
-          `
-        )}
+          `;
+        })}
       </div>
     `;
   }
@@ -1091,10 +1095,6 @@ export class UseCalendar extends LitElement {
     [part='picker-months'] {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
-    }
-
-    [part='picker-months'] [role='row'] {
-      display: contents;
     }
 
     [part~='picker-month'] {


### PR DESCRIPTION
Constrain the picker to the allowed date range: the year list now starts at the min year and ends at the max year, and months outside the min/max window are omitted from each year section.