### PR TITLE
feat(use-scrollarea): add scroll edge state web component

### DIFF
--- a/src/elements/use-scrollarea/index.ts
+++ b/src/elements/use-scrollarea/index.ts
@@ -1,0 +1,1 @@
+export { UseScrollarea } from './use-scrollarea';

--- a/src/elements/use-scrollarea/use-scrollarea.stories.ts
+++ b/src/elements/use-scrollarea/use-scrollarea.stories.ts
@@ -1,0 +1,271 @@
+import { html } from 'lit';
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { UseScrollarea } from './use-scrollarea';
+import './use-scrollarea';
+
+const meta: Meta<UseScrollarea> = {
+  title: 'Web Components/use-scrollarea',
+  component: 'use-scrollarea',
+  tags: ['autodocs', '!dev', 'utility'],
+};
+export default meta;
+
+type Story = StoryObj<UseScrollarea>;
+
+const scrollShadowStyles = html`
+  <style>
+    .scroll-demo {
+      overflow: auto;
+      height: 200px;
+      width: 300px;
+      border: 1px solid currentColor;
+      position: relative;
+    }
+
+    .scroll-demo::before,
+    .scroll-demo::after {
+      content: '';
+      display: block;
+      position: sticky;
+      inset-inline: 0;
+      height: 24px;
+      pointer-events: none;
+      z-index: 1;
+    }
+
+    .scroll-demo::before {
+      top: 0;
+      background: rgba(255, 0, 0, 0.5);
+    }
+
+    .scroll-demo::after {
+      bottom: 0;
+      background: rgba(255, 0, 0, 0.5);
+    }
+
+    .scroll-demo:state(at-block-start)::before {
+      display: none;
+    }
+
+    .scroll-demo:state(at-block-end)::after {
+      display: none;
+    }
+
+    .scroll-demo p {
+      margin: 0;
+      padding: 0.5rem;
+    }
+  </style>
+`;
+
+export const Vertical: Story = {
+  render: () => html`
+    ${scrollShadowStyles}
+    <use-scrollarea class="scroll-demo">
+      ${Array.from({ length: 20 }, (_, i) => html`<p>Line ${i + 1} — scroll to see shadows appear and disappear</p>`)}
+    </use-scrollarea>
+  `,
+};
+
+export const Horizontal: Story = {
+  render: () => html`
+    <style>
+      .scroll-h-wrapper {
+        position: relative;
+        width: 300px;
+        height: 80px;
+      }
+
+      .scroll-demo-h {
+        overflow: auto;
+        height: 100%;
+        width: 100%;
+        border: 1px solid currentColor;
+        white-space: nowrap;
+      }
+
+      .scroll-h-wrapper::before,
+      .scroll-h-wrapper::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 24px;
+        background: rgba(255, 0, 0, 0.5);
+        pointer-events: none;
+        z-index: 1;
+      }
+
+      .scroll-h-wrapper::before {
+        left: 0;
+      }
+
+      .scroll-h-wrapper::after {
+        right: 0;
+      }
+
+      .scroll-h-wrapper:has(use-scrollarea:state(at-inline-start))::before {
+        display: none;
+      }
+
+      .scroll-h-wrapper:has(use-scrollarea:state(at-inline-end))::after {
+        display: none;
+      }
+
+      .scroll-demo-h p {
+        display: inline;
+        padding: 0 0.5rem;
+      }
+    </style>
+    <div class="scroll-h-wrapper">
+      <use-scrollarea class="scroll-demo-h">
+        ${Array.from({ length: 20 }, (_, i) => html`<p>Item ${i + 1}</p>`)}
+      </use-scrollarea>
+    </div>
+  `,
+};
+
+export const Bidirectional: Story = {
+  render: () => html`
+    <style>
+      .scroll-2d-wrapper {
+        position: relative;
+        width: 300px;
+        height: 200px;
+      }
+
+      .scroll-demo-2d {
+        overflow: auto;
+        width: 100%;
+        height: 100%;
+        border: 1px solid currentColor;
+      }
+
+      .scroll-2d-shadow {
+        position: absolute;
+        background: rgba(255, 0, 0, 0.5);
+        pointer-events: none;
+        z-index: 1;
+      }
+
+      .scroll-2d-shadow-top,
+      .scroll-2d-shadow-bottom {
+        left: 0;
+        right: 0;
+        height: 24px;
+      }
+
+      .scroll-2d-shadow-top {
+        top: 0;
+      }
+
+      .scroll-2d-shadow-bottom {
+        bottom: 0;
+      }
+
+      .scroll-2d-shadow-left,
+      .scroll-2d-shadow-right {
+        top: 0;
+        bottom: 0;
+        width: 24px;
+      }
+
+      .scroll-2d-shadow-left {
+        left: 0;
+      }
+
+      .scroll-2d-shadow-right {
+        right: 0;
+      }
+
+      .scroll-2d-wrapper:has(use-scrollarea:state(at-block-start)) .scroll-2d-shadow-top {
+        display: none;
+      }
+
+      .scroll-2d-wrapper:has(use-scrollarea:state(at-block-end)) .scroll-2d-shadow-bottom {
+        display: none;
+      }
+
+      .scroll-2d-wrapper:has(use-scrollarea:state(at-inline-start)) .scroll-2d-shadow-left {
+        display: none;
+      }
+
+      .scroll-2d-wrapper:has(use-scrollarea:state(at-inline-end)) .scroll-2d-shadow-right {
+        display: none;
+      }
+
+      .scroll-demo-2d-inner {
+        width: 800px;
+      }
+
+      .scroll-demo-2d p {
+        margin: 0;
+        padding: 0.5rem;
+        white-space: nowrap;
+      }
+
+      .scroll-status {
+        margin-top: 0.5rem;
+        font-size: 0.85rem;
+        font-family: monospace;
+      }
+    </style>
+    <div class="scroll-2d-wrapper">
+      <div class="scroll-2d-shadow scroll-2d-shadow-top"></div>
+      <div class="scroll-2d-shadow scroll-2d-shadow-bottom"></div>
+      <div class="scroll-2d-shadow scroll-2d-shadow-left"></div>
+      <div class="scroll-2d-shadow scroll-2d-shadow-right"></div>
+      <use-scrollarea
+        class="scroll-demo-2d"
+        @scroll=${(e: Event) => {
+          const area = e.currentTarget as UseScrollarea;
+          const status = area.closest('.scroll-2d-wrapper')?.nextElementSibling;
+          if (status) {
+            const states = ['at-block-start', 'at-block-end', 'at-inline-start', 'at-inline-end']
+              .filter((s) => area.matches(`:state(${s})`))
+              .join(', ');
+            status.textContent = `Active states: ${states || 'none'}`;
+          }
+        }}
+      >
+        <div class="scroll-demo-2d-inner">
+          ${Array.from(
+            { length: 20 },
+            (_, i) => html`<p>Row ${i + 1} — wide content that overflows horizontally to trigger inline states</p>`
+          )}
+        </div>
+      </use-scrollarea>
+    </div>
+    <div class="scroll-status">Active states: at-block-start, at-inline-start</div>
+  `,
+};
+
+export const DynamicContent: Story = {
+  render: () => {
+    let count = 5;
+    return html`
+      ${scrollShadowStyles}
+      <use-scrollarea class="scroll-demo" id="dynamic-scroll">
+        ${Array.from({ length: count }, (_, i) => html`<p>Item ${i + 1}</p>`)}
+      </use-scrollarea>
+      <button
+        type="button"
+        style="margin-top: 0.5rem; display: block;"
+        @click=${() => {
+          const area = document.querySelector('#dynamic-scroll');
+          if (area) {
+            count++;
+            const p = document.createElement('p');
+            p.textContent = `Item ${count}`;
+            area.appendChild(p);
+          }
+        }}
+      >
+        Add item
+      </button>
+      <p style="font-size: 0.85rem; margin-top: 0.25rem;">
+        Add items until overflow — bottom shadow appears automatically.
+      </p>
+    `;
+  },
+};

--- a/src/elements/use-scrollarea/use-scrollarea.test.ts
+++ b/src/elements/use-scrollarea/use-scrollarea.test.ts
@@ -1,0 +1,114 @@
+import { expect, describe, it } from 'vitest';
+import { render } from 'vitest-browser-lit';
+import { html } from 'lit';
+
+import './use-scrollarea';
+import { UseScrollarea } from './use-scrollarea';
+
+describe('use-scrollarea', () => {
+  describe('initial states (no overflow)', () => {
+    it('has all four edge states when content does not overflow', async () => {
+      render(html`
+        <use-scrollarea style="height: 200px; overflow: auto;">
+          <p>Short content</p>
+        </use-scrollarea>
+      `);
+      const el = document.querySelector('use-scrollarea') as UseScrollarea;
+      await el.updateComplete;
+
+      expect(el.matches(':state(at-block-start)')).toBe(true);
+      expect(el.matches(':state(at-block-end)')).toBe(true);
+      expect(el.matches(':state(at-inline-start)')).toBe(true);
+      expect(el.matches(':state(at-inline-end)')).toBe(true);
+    });
+  });
+
+  describe('vertical scroll states', () => {
+    it('has at-block-start but not at-block-end when content overflows vertically', async () => {
+      render(html`
+        <use-scrollarea style="height: 100px; overflow: auto;">
+          ${Array.from({ length: 20 }, (_, i) => html`<p style="margin:0;line-height:2rem">Line ${i}</p>`)}
+        </use-scrollarea>
+      `);
+      const el = document.querySelector('use-scrollarea') as UseScrollarea;
+      await el.updateComplete;
+
+      expect(el.matches(':state(at-block-start)')).toBe(true);
+      expect(el.matches(':state(at-block-end)')).toBe(false);
+    });
+
+    it('has at-block-end but not at-block-start after scrolling to bottom', async () => {
+      render(html`
+        <use-scrollarea style="height: 100px; overflow: auto;">
+          ${Array.from({ length: 20 }, (_, i) => html`<p style="margin:0;line-height:2rem">Line ${i}</p>`)}
+        </use-scrollarea>
+      `);
+      const el = document.querySelector('use-scrollarea') as UseScrollarea;
+      await el.updateComplete;
+
+      el.scrollTop = el.scrollHeight;
+      el.dispatchEvent(new Event('scroll'));
+      await el.updateComplete;
+
+      expect(el.matches(':state(at-block-start)')).toBe(false);
+      expect(el.matches(':state(at-block-end)')).toBe(true);
+    });
+  });
+
+  describe('horizontal scroll states', () => {
+    it('has at-inline-start but not at-inline-end when content overflows horizontally', async () => {
+      render(html`
+        <use-scrollarea style="width: 100px; overflow: auto; white-space: nowrap;">
+          <span style="display:inline-block;width:800px;">wide content</span>
+        </use-scrollarea>
+      `);
+      const el = document.querySelector('use-scrollarea') as UseScrollarea;
+      await el.updateComplete;
+
+      expect(el.matches(':state(at-inline-start)')).toBe(true);
+      expect(el.matches(':state(at-inline-end)')).toBe(false);
+    });
+
+    it('has at-inline-end but not at-inline-start after scrolling to end', async () => {
+      render(html`
+        <use-scrollarea style="width: 100px; overflow: auto; white-space: nowrap;">
+          <span style="display:inline-block;width:800px;">wide content</span>
+        </use-scrollarea>
+      `);
+      const el = document.querySelector('use-scrollarea') as UseScrollarea;
+      await el.updateComplete;
+
+      el.scrollLeft = el.scrollWidth;
+      el.dispatchEvent(new Event('scroll'));
+      await el.updateComplete;
+
+      expect(el.matches(':state(at-inline-start)')).toBe(false);
+      expect(el.matches(':state(at-inline-end)')).toBe(true);
+    });
+  });
+
+  describe('dynamic content', () => {
+    it('updates states when content is added that causes overflow', async () => {
+      render(html`
+        <use-scrollarea style="height: 100px; overflow: auto;">
+          <p style="margin:0;line-height:2rem">Line 1</p>
+        </use-scrollarea>
+      `);
+      const el = document.querySelector('use-scrollarea') as UseScrollarea;
+      await el.updateComplete;
+
+      expect(el.matches(':state(at-block-end)')).toBe(true);
+
+      for (let i = 2; i <= 20; i++) {
+        const p = document.createElement('p');
+        p.style.cssText = 'margin:0;line-height:2rem';
+        p.textContent = `Line ${i}`;
+        el.appendChild(p);
+      }
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(el.matches(':state(at-block-end)')).toBe(false);
+    });
+  });
+});

--- a/src/elements/use-scrollarea/use-scrollarea.ts
+++ b/src/elements/use-scrollarea/use-scrollarea.ts
@@ -1,0 +1,82 @@
+import { LitElement, css, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+/**
+ * A scroll container that exposes custom states for scroll edge detection.
+ *
+ * ## Custom States
+ * The following CSS custom states are available for styling:
+ *
+ * - `:state(at-block-start)` — scrolled to the block-start edge (top in horizontal writing modes)
+ * - `:state(at-block-end)` — scrolled to the block-end edge (bottom in horizontal writing modes)
+ * - `:state(at-inline-start)` — scrolled to the inline-start edge (left in LTR)
+ * - `:state(at-inline-end)` — scrolled to the inline-end edge (right in LTR)
+ *
+ * @slot - Scrollable content
+ */
+@customElement('use-scrollarea')
+export class UseScrollarea extends LitElement {
+  #internals: ElementInternals;
+  #resizeObserver: ResizeObserver | null = null;
+  #mutationObserver: MutationObserver | null = null;
+
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('scroll', this.#onScroll, { passive: true });
+    this.#resizeObserver = new ResizeObserver(this.#updateScrollStates);
+    this.#resizeObserver.observe(this);
+    this.#mutationObserver = new MutationObserver(this.#updateScrollStates);
+    this.#mutationObserver.observe(this, { childList: true, subtree: true });
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('scroll', this.#onScroll);
+    this.#resizeObserver?.disconnect();
+    this.#resizeObserver = null;
+    this.#mutationObserver?.disconnect();
+    this.#mutationObserver = null;
+    super.disconnectedCallback();
+  }
+
+  firstUpdated() {
+    this.#updateScrollStates();
+  }
+
+  #onScroll = () => {
+    this.#updateScrollStates();
+  };
+
+  #updateScrollStates = () => {
+    const atBlockStart = this.scrollTop <= 0;
+    const atBlockEnd = Math.abs(this.scrollHeight - this.scrollTop - this.clientHeight) < 1;
+    const absScrollLeft = Math.abs(this.scrollLeft);
+    const atInlineStart = absScrollLeft <= 0;
+    const atInlineEnd = Math.abs(absScrollLeft + this.clientWidth - this.scrollWidth) < 1;
+
+    this.#internals.states[atBlockStart ? 'add' : 'delete']('at-block-start');
+    this.#internals.states[atBlockEnd ? 'add' : 'delete']('at-block-end');
+    this.#internals.states[atInlineStart ? 'add' : 'delete']('at-inline-start');
+    this.#internals.states[atInlineEnd ? 'add' : 'delete']('at-inline-end');
+  };
+
+  render() {
+    return html`<slot></slot>`;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'use-scrollarea': UseScrollarea;
+  }
+}

--- a/src/use-wc.ts
+++ b/src/use-wc.ts
@@ -12,3 +12,4 @@ export * from './elements/use-widget/use-widget';
 export * from './elements/use-menu/use-menu';
 export * from './elements/use-calendar/use-calendar';
 export * from './elements/use-datetime/use-datetime';
+export * from './elements/use-scrollarea/use-scrollarea';


### PR DESCRIPTION
## Summary

- Adds `use-scrollarea` web component that tracks scroll position and exposes four CSS custom states: `at-block-start`, `at-block-end`, `at-inline-start`, `at-inline-end`
- States update on scroll, resize (via `ResizeObserver`), and dynamic content changes (via `MutationObserver`)
- Enables pure-CSS scroll shadows and fade effects using `:state()` and `:has()` without any JavaScript in consumer code

## Test plan

- [ ] All 6 unit tests pass (`npm run test`)
- [ ] Storybook stories render correctly: Vertical, Horizontal, Bidirectional, DynamicContent
- [ ] Red shadow indicators appear/disappear correctly as you scroll each story
- [ ] Bidirectional story shows multiple active states simultaneously in status text

🤖 Generated with [Claude Code](https://claude.com/claude-code)