### PR TITLE
feat(docs): generate markdown files for AI consumption

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
   "types": "./dist/use-wc.d.ts",
   "exports": {
     ".": "./dist/use-wc.mjs",
+    "./design-tokens.css": "./dist/design-tokens.css",
+    "./design-system.css": "./dist/design-system.css",
     "./package.json": "./package.json"
   },
   "scripts": {
-    "pack": "tsc && vp run analyze && vp pack",
+    "pack": "tsc && vp run analyze && vp pack && vp run generate-docs",
     "preview": "vp preview",
     "analyze": "custom-elements-manifest analyze",
+    "generate-docs": "node scripts/generate-docs.mjs",
     "storybook": "storybook dev -p ${PORT:-6006}",
     "build": "vp run pack && storybook build",
     "test": "vp test",

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -73,17 +73,12 @@ function generateMarkdown(declaration) {
       typeText(event.type),
       descriptionText(event.description),
     ]);
-    sections.push(
-      `## Events\n\n${renderTable(["Name", "Type", "Description"], rows)}`,
-    );
+    sections.push(`## Events\n\n${renderTable(["Name", "Type", "Description"], rows)}`);
   }
 
   const slots = declaration.slots ?? [];
   if (slots.length > 0) {
-    const rows = slots.map((slot) => [
-      `\`${slot.name}\``,
-      descriptionText(slot.description),
-    ]);
+    const rows = slots.map((slot) => [`\`${slot.name}\``, descriptionText(slot.description)]);
     sections.push(`## Slots\n\n${renderTable(["Name", "Description"], rows)}`);
   }
 
@@ -105,18 +100,14 @@ function generateMarkdown(declaration) {
       escapeCell(state.name),
       descriptionText(state.description),
     ]);
-    sections.push(
-      `## CSS States\n\n${renderTable(["State", "Description"], rows)}`,
-    );
+    sections.push(`## CSS States\n\n${renderTable(["State", "Description"], rows)}`);
   }
 
   return sections.join("\n\n");
 }
 
 if (!existsSync(manifestPath)) {
-  console.error(
-    `custom-elements.json not found at ${manifestPath}. Run 'vp run analyze' first.`,
-  );
+  console.error(`custom-elements.json not found at ${manifestPath}. Run 'vp run analyze' first.`);
   process.exit(1);
 }
 

--- a/scripts/generate-docs.mjs
+++ b/scripts/generate-docs.mjs
@@ -1,0 +1,137 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(scriptsDir, "..");
+const manifestPath = resolve(projectRoot, "custom-elements.json");
+const outputDir = resolve(projectRoot, "dist", "docs");
+
+function escapeCell(value) {
+  return value.replace(/\|/g, "\\|");
+}
+
+function renderTable(headers, rows) {
+  const headerRow = `| ${headers.join(" | ")} |`;
+  const separatorRow = `| ${headers.map(() => "---").join(" | ")} |`;
+  const dataRows = rows.map((cells) => `| ${cells.join(" | ")} |`);
+  return [headerRow, separatorRow, ...dataRows].join("\n");
+}
+
+function typeText(type) {
+  return type?.text ? `\`${escapeCell(type.text)}\`` : "-";
+}
+
+function defaultText(value) {
+  return value !== undefined ? `\`${escapeCell(value)}\`` : "-";
+}
+
+function descriptionText(value) {
+  return value ? escapeCell(value) : "-";
+}
+
+function generateMarkdown(declaration) {
+  const sections = [];
+
+  const header = declaration.description
+    ? `# \`${declaration.tagName}\`\n\n${declaration.description}`
+    : `# \`${declaration.tagName}\``;
+  sections.push(header);
+
+  const attributes = declaration.attributes ?? [];
+  if (attributes.length > 0) {
+    const rows = attributes.map((attribute) => [
+      escapeCell(attribute.name),
+      typeText(attribute.type),
+      defaultText(attribute.default),
+      descriptionText(attribute.description),
+    ]);
+    sections.push(
+      `## Attributes\n\n${renderTable(["Name", "Type", "Default", "Description"], rows)}`,
+    );
+  }
+
+  const jsOnlyProperties = (declaration.members ?? []).filter(
+    (member) => member.kind === "field" && !("attribute" in member),
+  );
+  if (jsOnlyProperties.length > 0) {
+    const rows = jsOnlyProperties.map((member) => [
+      escapeCell(member.name),
+      typeText(member.type),
+      defaultText(member.default),
+      descriptionText(member.description),
+    ]);
+    sections.push(
+      `## Properties\n\n${renderTable(["Name", "Type", "Default", "Description"], rows)}`,
+    );
+  }
+
+  const events = declaration.events ?? [];
+  if (events.length > 0) {
+    const rows = events.map((event) => [
+      escapeCell(event.name),
+      typeText(event.type),
+      descriptionText(event.description),
+    ]);
+    sections.push(
+      `## Events\n\n${renderTable(["Name", "Type", "Description"], rows)}`,
+    );
+  }
+
+  const slots = declaration.slots ?? [];
+  if (slots.length > 0) {
+    const rows = slots.map((slot) => [
+      `\`${slot.name}\``,
+      descriptionText(slot.description),
+    ]);
+    sections.push(`## Slots\n\n${renderTable(["Name", "Description"], rows)}`);
+  }
+
+  const cssProperties = declaration.cssProperties ?? [];
+  if (cssProperties.length > 0) {
+    const rows = cssProperties.map((property) => [
+      escapeCell(property.name),
+      defaultText(property.default),
+      descriptionText(property.description),
+    ]);
+    sections.push(
+      `## CSS Custom Properties\n\n${renderTable(["Name", "Default", "Description"], rows)}`,
+    );
+  }
+
+  const cssStates = declaration.cssStates ?? [];
+  if (cssStates.length > 0) {
+    const rows = cssStates.map((state) => [
+      escapeCell(state.name),
+      descriptionText(state.description),
+    ]);
+    sections.push(
+      `## CSS States\n\n${renderTable(["State", "Description"], rows)}`,
+    );
+  }
+
+  return sections.join("\n\n");
+}
+
+if (!existsSync(manifestPath)) {
+  console.error(
+    `custom-elements.json not found at ${manifestPath}. Run 'vp run analyze' first.`,
+  );
+  process.exit(1);
+}
+
+const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+
+const declarations = manifest.modules
+  .flatMap((module) => module.declarations ?? [])
+  .filter((declaration) => declaration.tagName !== undefined);
+
+mkdirSync(outputDir, { recursive: true });
+
+for (const declaration of declarations) {
+  const markdown = generateMarkdown(declaration);
+  const outputPath = resolve(outputDir, `${declaration.tagName}.md`);
+  writeFileSync(outputPath, markdown + "\n", "utf-8");
+}
+
+console.log(`Generated docs for ${declarations.length} components.`);

--- a/src/elements/use-grid/use-grid.ts
+++ b/src/elements/use-grid/use-grid.ts
@@ -10,13 +10,6 @@ type Indicator = (typeof indicators)[number];
 /**
  * Accessible grid component following [WAI-ARIA grid pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/).
  *
- * ## Grid Cell Modes
- * The `mode` attribute of the `use-gridcell` element determines how the cell behaves in terms of focus and interaction. The possible values are:
- *
- * - `'none'` - the cell itself is focusable and it does not contain any interactive elements.
- * - `'widget'` - the cell itself is focusable and it contains more than one interactive element. To access the interactive elements, the user must press `Enter` or `F2`, and to restore focus to the cell, the user must press `Esc` or `F2`.
- * - `'action'` - the cell itself is not focusable and it contains a single interactive element. The user can tab to the interactive elements directly.
- *
  * @slot - Grid content (use-gridhead/use-gridbody rows)
  */
 @customElement("use-grid")

--- a/src/elements/use-grid/use-gridcell.ts
+++ b/src/elements/use-grid/use-gridcell.ts
@@ -1,8 +1,16 @@
-import { property } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import { UseWidget } from "../use-widget/use-widget";
 import { tabbable } from "tabbable";
 
+@customElement("use-gridcell")
 export class UseGridCell extends UseWidget {
+  /**
+   * Determines how the cell behaves in terms of focus and interaction. The possible values are:
+   *
+   * - `'none'` - the cell itself is focusable and it does not contain any interactive elements.
+   * - `'widget'` - the cell itself is focusable and it contains more than one interactive element. To access the interactive elements, the user must press `Enter` or `F2`, and to restore focus to the cell, the user must press `Esc` or `F2`.
+   * - `'action'` - the cell itself is not focusable and it contains a single interactive element. The user can tab to the interactive elements directly.
+   */
   @property({ type: String, reflect: true })
   mode: "widget" | "action" | "default" = "default";
   #action: HTMLElement | null = null;
@@ -48,8 +56,6 @@ export class UseGridCell extends UseWidget {
     }
   }
 }
-
-customElements.define("use-gridcell", UseGridCell);
 
 declare global {
   interface HTMLElementTagNameMap {


### PR DESCRIPTION
## Summary

- Replace manual `customElements.define` with `@customElement` decorator in `use-gridcell`
- Move grid cell mode documentation from `use-grid` JSDoc to the `mode` property on `use-gridcell`
- Add `design-tokens` and `design-system` CSS exports to `package.json`
- Add `generate-docs` script wired into the `pack` pipeline

## Test plan

- [ ] `vp lint` passes
- [ ] `vp test` passes (85 tests)
- [ ] `vp run build` (Storybook build) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)