### PR TITLE
feat(use-dropdown): design-system button styles and listbox hover/wrap improvements

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -642,7 +642,7 @@
         content: attr(aria-label);
         padding: var(--usewc-layout-popover-menu-padding);
         font-size: var(--usewc-layout-popover-menu-header-font-size);
-        font-weight: var(--usewc-effect-popover-menu-header-font-weight);
+        font-weight: var(--usewc-font-popover-menu-header-weight);
         color: var(--usewc-color-popover-menu-header-text);
       }
     }


### PR DESCRIPTION
## Summary

- Applies design-system button tokens (`--usewc-color-button-base-*`, `--usewc-layout-button-base-*`) to `use-dropdown::part(trigger)` via CSS, replacing the inline chevron text with a CSS background-image chevron
- Sets `activeOption` on `mouseover` in `use-listbox-input` so `use-option` gains `:state(active)` on hover, with the last active item persisting when the mouse leaves
- Wraps `ArrowUp`/`ArrowDown` navigation to cycle from last→first and first→last respectively
- Fixes a broken CSS custom property reference: `--usewc-effect-popover-menu-header-font-weight` → `--usewc-font-popover-menu-header-weight` (was falling through to browser default)

## Test plan

- [ ] Confirm `use-dropdown` trigger matches design-system button styling
- [ ] Hover over options in `use-listbox-input` — active highlight should follow the cursor
- [ ] Arrow key past the last option wraps to the first; past the first wraps to the last
- [ ] Verify popover menu group headers render with medium font-weight (not browser default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)