### PR TITLE
fix(theme): prevent button gradient backgrounds from repeating

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -251,6 +251,9 @@
       cursor: default;
       color: var(--usewc-theme-color-button-text-static);
       background: var(--usewc-theme-color-button-background-static);
+      background-size: var(--usewc-layout-button-background-size);
+      background-position: var(--usewc-layout-button-background-position);
+      background-repeat: var(--usewc-layout-button-background-repeat);
       border: var(--usewc-layout-button-border) var(--usewc-effect-input-border-style)
         var(--usewc-theme-color-button-border-static);
     }

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -166,6 +166,10 @@
   --usewc-color-button-cancel-text-active: var(--usewc-color-gray-700);
   /* - Layout */
   --usewc-layout-button-border: var(--usewc-space-1);
+  --usewc-layout-button-background-size: calc(100% + var(--usewc-layout-button-border) * 2)
+    calc(100% + var(--usewc-layout-button-border) * 2);
+  --usewc-layout-button-background-position: center;
+  --usewc-layout-button-background-repeat: no-repeat;
   --usewc-layout-button-line-height: var(--usewc-line-height-24);
   /* - Effect */
   --usewc-effect-button-border-radius: var(--usewc-effect-border-radius-4);


### PR DESCRIPTION
## Summary

- Adds three new semantic layout tokens (`--usewc-layout-button-background-size`, `--usewc-layout-button-background-position`, `--usewc-layout-button-background-repeat`) in `src/styles/tokens/semantic.css`
- Applies those tokens to the base button visual rule in `src/styles/theme.css` so gradient backgrounds cover the full border-box and do not tile

## Why

CSS gradients default to `background-size: auto` and `background-repeat: repeat`, which causes them to tile across the button. The `background-size` token accounts for the button's border width (`--usewc-layout-button-border`) so the gradient stretches to cover the full border-box, not just the padding box.

## Reviewer notes

- Token defaults are non-breaking for solid-color backgrounds (they have no visible effect)
- Consumers can override the tokens to customize gradient behavior (size, position, repeat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)