### PR TITLE
feat(stories): box model playground + token cleanup

### DIFF
--- a/src/stories/box-model-playground.stories.ts
+++ b/src/stories/box-model-playground.stories.ts
@@ -1,0 +1,763 @@
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+import { html } from "lit";
+import { ref } from "lit/directives/ref.js";
+import "../styles/tokens.css";
+import atomicCss from "../styles/tokens/atomic.css?raw";
+import semanticCss from "../styles/tokens/semantic.css?raw";
+
+const allTokens = Array.from(
+  new Set(`${atomicCss}\n${semanticCss}`.match(/--usewc-[a-z0-9-]+/g) ?? []),
+).sort();
+
+function tokensMatching(...prefixes: string[]) {
+  return allTokens.filter((token) => prefixes.some((prefix) => token.startsWith(prefix)));
+}
+
+const tokenLists = {
+  color: tokensMatching("--usewc-color-"),
+  size: tokensMatching("--usewc-size-", "--usewc-space-"),
+  font: tokensMatching("--usewc-font-", "--usewc-line-height-"),
+  effect: tokensMatching("--usewc-effect-", "--usewc-transition-"),
+  all: allTokens,
+};
+
+type TokenCategory = "color" | "space" | "layout" | "font" | "effect";
+
+type PlaygroundProperty = {
+  name: string;
+  list: keyof typeof tokenLists;
+  category: TokenCategory;
+  defaultValue?: string;
+  stateDefaults?: Partial<Record<State, string>>;
+  options?: readonly string[];
+};
+
+const layoutProperties: ReadonlyArray<PlaygroundProperty> = [
+  {
+    name: "box-sizing",
+    list: "all",
+    category: "layout",
+    defaultValue: "border-box",
+    options: ["content-box", "border-box"],
+  },
+  {
+    name: "display",
+    list: "all",
+    category: "layout",
+    defaultValue: "inline-flex",
+    options: ["block", "flex", "inline-flex", "inline-block", "grid", "inline", "none"],
+  },
+  {
+    name: "flex-direction",
+    list: "all",
+    category: "layout",
+    defaultValue: "row",
+    options: ["row", "row-reverse", "column", "column-reverse"],
+  },
+  {
+    name: "align-items",
+    list: "all",
+    category: "layout",
+    defaultValue: "center",
+    options: ["stretch", "flex-start", "center", "flex-end", "baseline"],
+  },
+  {
+    name: "justify-content",
+    list: "all",
+    category: "layout",
+    defaultValue: "center",
+    options: ["flex-start", "center", "flex-end", "space-between", "space-around", "space-evenly"],
+  },
+  { name: "margin-block", list: "size", category: "space" },
+  { name: "margin-inline", list: "size", category: "space" },
+  { name: "margin", list: "size", category: "space", defaultValue: "0" },
+  {
+    name: "border-size",
+    list: "size",
+    category: "layout",
+    defaultValue: "var(--usewc-layout-button-border)",
+  },
+  {
+    name: "padding-block",
+    list: "size",
+    category: "layout",
+    defaultValue: "var(--usewc-layout-button-base-padding-block)",
+  },
+  {
+    name: "padding-inline",
+    list: "size",
+    category: "layout",
+    defaultValue: "var(--usewc-layout-button-base-padding-inline)",
+  },
+  { name: "padding", list: "size", category: "layout" },
+  {
+    name: "line-height",
+    list: "font",
+    category: "layout",
+    defaultValue: "var(--usewc-layout-button-line-height)",
+  },
+  {
+    name: "gap",
+    list: "size",
+    category: "layout",
+    defaultValue: "var(--usewc-layout-button-base-gap)",
+  },
+  {
+    name: "font-size",
+    list: "font",
+    category: "layout",
+    defaultValue: "var(--usewc-layout-button-base-font-size)",
+  },
+];
+
+const effectProperties: ReadonlyArray<PlaygroundProperty> = [
+  {
+    name: "border-style",
+    list: "all",
+    category: "effect",
+    defaultValue: "var(--usewc-effect-input-border-style)",
+  },
+  {
+    name: "border-color",
+    list: "color",
+    category: "color",
+    defaultValue: "var(--usewc-color-button-base-border-static)",
+    stateDefaults: {
+      hover: "var(--usewc-color-button-base-border-hover)",
+      active: "var(--usewc-color-button-base-border-active)",
+    },
+  },
+  {
+    name: "border-radius",
+    list: "effect",
+    category: "effect",
+    defaultValue: "var(--usewc-effect-input-border-radius)",
+  },
+  { name: "corner-shape", list: "all", category: "effect" },
+  { name: "outline-size", list: "size", category: "effect" },
+  { name: "outline-style", list: "all", category: "effect" },
+  { name: "outline-color", list: "color", category: "color" },
+  { name: "outline-offset", list: "size", category: "effect" },
+  { name: "box-shadow", list: "effect", category: "effect" },
+  {
+    name: "background",
+    list: "color",
+    category: "color",
+    defaultValue: "var(--usewc-color-button-base-background-static)",
+    stateDefaults: {
+      hover: "var(--usewc-color-button-base-background-hover)",
+      active: "var(--usewc-color-button-base-background-active)",
+    },
+  },
+  { name: "background-image", list: "all", category: "effect" },
+  { name: "background-repeat", list: "all", category: "layout" },
+  { name: "background-size", list: "size", category: "layout" },
+  {
+    name: "color",
+    list: "color",
+    category: "color",
+    defaultValue: "var(--usewc-color-button-base-text-static)",
+    stateDefaults: {
+      hover: "var(--usewc-color-button-base-text-hover)",
+      active: "var(--usewc-color-button-base-text-active)",
+    },
+  },
+  { name: "text-decoration", list: "all", category: "effect" },
+  {
+    name: "font-weight",
+    list: "font",
+    category: "font",
+    defaultValue: "var(--usewc-font-weight-normal)",
+  },
+  {
+    name: "font-family",
+    list: "font",
+    category: "font",
+    defaultValue: "var(--usewc-font-input-family)",
+  },
+  { name: "transform", list: "all", category: "effect" },
+  { name: "opacity", list: "all", category: "effect" },
+  { name: "cursor", list: "all", category: "effect", defaultValue: "default" },
+];
+
+const animationProperties: ReadonlyArray<PlaygroundProperty> = [
+  { name: "transition", list: "effect", category: "effect" },
+];
+
+const propertyGroups: ReadonlyArray<{
+  caption: string;
+  properties: ReadonlyArray<PlaygroundProperty>;
+}> = [
+  { caption: "Layout", properties: layoutProperties },
+  { caption: "Effect", properties: effectProperties },
+  { caption: "Animation", properties: animationProperties },
+];
+
+const STATES = [
+  "static",
+  "hover",
+  "focus",
+  "active",
+  "pressed",
+  "selected",
+  "checked",
+  "invalid",
+  "valid",
+  "disabled",
+  "readonly",
+] as const;
+type State = (typeof STATES)[number];
+
+const STATE_ATTRIBUTES: Partial<Record<State, { attribute: string; value: string }>> = {
+  pressed: { attribute: "aria-pressed", value: "true" },
+  selected: { attribute: "aria-selected", value: "true" },
+  checked: { attribute: "aria-checked", value: "true" },
+  invalid: { attribute: "aria-invalid", value: "true" },
+  valid: { attribute: "aria-invalid", value: "false" },
+  disabled: { attribute: "aria-disabled", value: "true" },
+  readonly: { attribute: "aria-readonly", value: "true" },
+};
+
+function stateSelectorSuffixes(state: State): readonly string[] {
+  switch (state) {
+    case "static":
+      return [""];
+    case "hover":
+      return [":hover"];
+    case "focus":
+      return [":focus", ":focus-visible"];
+    case "active":
+      return [":active"];
+    default: {
+      const attributeInfo = STATE_ATTRIBUTES[state];
+      return attributeInfo ? [`[${attributeInfo.attribute}="${attributeInfo.value}"]`] : [""];
+    }
+  }
+}
+
+const STYLE_ID = "box-model-playground-style";
+const GENERATED_ID = "box-model-playground-generated";
+const DIMENSIONS_ID = "box-model-playground-dimensions";
+const BOX_CLASS = "box-model-playground-box";
+const PARENT_CLASS = "box-model-playground-parent";
+const STORAGE_KEY = "box-model-playground-values-v4";
+
+const cssPropertyOverrides: Record<string, string> = {
+  "border-size": "border-width",
+  "outline-size": "outline-width",
+};
+
+function cssPropertyFor(property: string) {
+  return cssPropertyOverrides[property] ?? property;
+}
+
+function saveValues(form: HTMLFormElement) {
+  const values: Record<string, string> = {};
+  for (const [key, raw] of new FormData(form).entries()) {
+    values[key] = String(raw);
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(values));
+  } catch {
+    // localStorage may be unavailable (private mode, sandboxed iframe)
+  }
+}
+
+function restoreValues(form: HTMLFormElement) {
+  let stored: string | null = null;
+  try {
+    stored = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return;
+  }
+  if (!stored) return;
+  let values: Record<string, string>;
+  try {
+    values = JSON.parse(stored);
+  } catch {
+    return;
+  }
+  for (const [key, value] of Object.entries(values)) {
+    const field = form.elements.namedItem(key);
+    if (field instanceof HTMLInputElement) {
+      if (field.type === "checkbox") {
+        field.checked = true;
+      } else {
+        field.value = value;
+      }
+    } else if (field instanceof HTMLSelectElement || field instanceof RadioNodeList) {
+      field.value = value;
+    }
+  }
+}
+
+function getActiveState(form: HTMLFormElement): State {
+  const field = form.elements.namedItem("__state");
+  const value = field instanceof RadioNodeList ? field.value : "";
+  return (STATES as readonly string[]).includes(value) ? (value as State) : "static";
+}
+
+function getScope(form: HTMLFormElement, state: State): "self" | "parent" {
+  const field = form.elements.namedItem(`scope:${state}`);
+  return field instanceof HTMLSelectElement && field.value === "parent" ? "parent" : "self";
+}
+
+function collectValues(formData: FormData) {
+  const byState: Partial<Record<State, Record<string, string>>> = {};
+  for (const [key, raw] of formData.entries()) {
+    if (key.startsWith("__") || key.startsWith("scope:")) continue;
+    const value = String(raw).trim();
+    if (!value) continue;
+    const separator = key.lastIndexOf(":");
+    if (separator === -1) continue;
+    const property = key.slice(0, separator);
+    const state = key.slice(separator + 1) as State;
+    if (!(STATES as readonly string[]).includes(state)) continue;
+    (byState[state] ??= {})[cssPropertyFor(property)] = value;
+  }
+  return byState;
+}
+
+function renderBlock(properties: Record<string, string>) {
+  return Object.entries(properties)
+    .map(([property, value]) => `  ${property}: ${value};`)
+    .join("\n");
+}
+
+const COLOR_REMAP_PARTS = ["background", "border", "text"] as const;
+const COLOR_REMAP_STATES = ["static", "hover", "active"] as const;
+const SIZE_REMAP_PROPERTIES = ["padding-block", "padding-inline", "gap", "font-size"] as const;
+
+function applyVariantRemap(staticProps: Record<string, string>, variant: string) {
+  const trimmed = variant.trim();
+  if (!trimmed || trimmed === "base") return;
+  for (const part of COLOR_REMAP_PARTS) {
+    for (const state of COLOR_REMAP_STATES) {
+      const key = `--usewc-color-button-base-${part}-${state}`;
+      staticProps[key] = `var(--usewc-color-button-${trimmed}-${part}-${state})`;
+    }
+  }
+}
+
+function applySizeRemap(staticProps: Record<string, string>, size: string) {
+  const trimmed = size.trim();
+  if (!trimmed || trimmed === "base" || trimmed === "medium") return;
+  for (const property of SIZE_REMAP_PROPERTIES) {
+    staticProps[`--usewc-layout-button-base-${property}`] =
+      `var(--usewc-layout-button-${trimmed}-${property})`;
+  }
+  staticProps["--usewc-layout-button-line-height"] =
+    `var(--usewc-layout-button-${trimmed}-line-height)`;
+}
+
+function getMacroValue(form: HTMLFormElement, name: string) {
+  const field = form.elements.namedItem(name);
+  return field instanceof HTMLInputElement ? field.value : "";
+}
+
+function buildStylesheet(form: HTMLFormElement) {
+  const byState = collectValues(new FormData(form));
+  const staticProps = (byState.static ??= {});
+  applyVariantRemap(staticProps, getMacroValue(form, "__variant"));
+  applySizeRemap(staticProps, getMacroValue(form, "__size"));
+  const blocks: string[] = [];
+  for (const state of STATES) {
+    const properties = byState[state];
+    if (!properties || Object.keys(properties).length === 0) continue;
+    const scope = state === "static" ? "self" : getScope(form, state);
+    const selectors = stateSelectorSuffixes(state).map((suffix) =>
+      scope === "parent" ? `.${PARENT_CLASS}${suffix} .${BOX_CLASS}` : `.${BOX_CLASS}${suffix}`,
+    );
+    blocks.push(`${selectors.join(",\n")} {\n${renderBlock(properties)}\n}`);
+  }
+  return blocks.join("\n\n");
+}
+
+function syncPanels(form: HTMLFormElement, root: Document | ShadowRoot) {
+  const activeState = getActiveState(form);
+  root.querySelectorAll<HTMLElement>("[data-state-panel]").forEach((panel) => {
+    panel.hidden = panel.dataset.statePanel !== activeState;
+  });
+}
+
+function updatePreview(form: HTMLFormElement, root: Document | ShadowRoot) {
+  const box = root.querySelector<HTMLElement>(`.${BOX_CLASS}`);
+  const parent = root.querySelector<HTMLElement>(`.${PARENT_CLASS}`);
+  for (const { attribute } of Object.values(STATE_ATTRIBUTES)) {
+    box?.removeAttribute(attribute);
+    parent?.removeAttribute(attribute);
+  }
+  const activeState = getActiveState(form);
+  const attributeInfo = STATE_ATTRIBUTES[activeState];
+  if (!attributeInfo) return;
+  const checkbox = form.elements.namedItem(`__preview-${activeState}`);
+  if (!(checkbox instanceof HTMLInputElement) || !checkbox.checked) return;
+  const target = getScope(form, activeState) === "parent" ? parent : box;
+  target?.setAttribute(attributeInfo.attribute, attributeInfo.value);
+}
+
+function updateTokenDisplays(form: HTMLFormElement, root: Document | ShadowRoot) {
+  const component = getMacroValue(form, "__component").trim();
+  const part = getMacroValue(form, "__part").trim();
+  const variant = getMacroValue(form, "__variant").trim();
+  const codes = root.querySelectorAll<HTMLElement>("[data-token-display]");
+  codes.forEach((code) => {
+    const fieldName = code.dataset.tokenDisplay ?? "";
+    const propertyName = code.dataset.property ?? "";
+    const category = code.dataset.category ?? "";
+    const state = code.dataset.state ?? "";
+    const stateSegment = state === "static" ? "" : state;
+    const tokenName = ["--usewc", category, component, part, variant, propertyName, stateSegment]
+      .filter(Boolean)
+      .join("-");
+    const field = form.elements.namedItem(fieldName);
+    let value = "";
+    if (field instanceof HTMLInputElement || field instanceof HTMLSelectElement) {
+      value = field.value;
+    }
+    code.textContent = value ? `${tokenName}: ${value};` : tokenName;
+  });
+}
+
+function applyStylesheet(form: HTMLFormElement) {
+  const stylesheet = buildStylesheet(form);
+  const root = form.getRootNode() as Document | ShadowRoot;
+  const host = (root as Document).head ?? form.parentElement ?? form;
+  let styleNode = (root as Document).getElementById?.(STYLE_ID) as HTMLStyleElement | null;
+  if (!styleNode) {
+    styleNode = document.createElement("style");
+    styleNode.id = STYLE_ID;
+    host.appendChild(styleNode);
+  }
+  styleNode.textContent = stylesheet;
+
+  const generated = (root as Document).getElementById?.(GENERATED_ID) as HTMLPreElement | null;
+  if (generated) {
+    generated.textContent = stylesheet || "/* (no values yet) */";
+  }
+
+  syncPanels(form, root);
+  updatePreview(form, root);
+  updateTokenDisplays(form, root);
+
+  const box = (root as Document).querySelector?.(`.${BOX_CLASS}`) as HTMLElement | null;
+  const dimensions = (root as Document).getElementById?.(DIMENSIONS_ID) as HTMLElement | null;
+  if (box && dimensions) {
+    const rect = box.getBoundingClientRect();
+    dimensions.textContent = `${rect.width.toFixed(1)}px × ${rect.height.toFixed(1)}px`;
+  }
+
+  saveValues(form);
+}
+
+function handleFormChange(event: Event) {
+  applyStylesheet(event.currentTarget as HTMLFormElement);
+}
+
+function handleFormInput(event: Event) {
+  applyStylesheet(event.currentTarget as HTMLFormElement);
+}
+
+function handleFormReady(form?: Element) {
+  if (form) {
+    requestAnimationFrame(() => {
+      const formElement = form as HTMLFormElement;
+      restoreValues(formElement);
+      applyStylesheet(formElement);
+    });
+  }
+}
+
+async function handleCopyToClipboard() {
+  const generated = document.getElementById(GENERATED_ID);
+  const value = generated?.textContent ?? "";
+  await window.top?.navigator.clipboard.writeText(value);
+}
+
+function boxIcon(label: string) {
+  return html`
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label=${label}
+      style="flex: none;"
+    >
+      <circle cx="8" cy="8" r="6" fill="currentColor" />
+    </svg>
+  `;
+}
+
+function renderDatalists() {
+  return Object.entries(tokenLists).map(
+    ([key, tokens]) => html`
+      <datalist id="box-model-tokens-${key}">
+        ${tokens.map((token) => html`<option value="var(${token})">${token}</option>`)}
+      </datalist>
+    `,
+  );
+}
+
+function renderControl(property: PlaygroundProperty, state: State) {
+  const name = `${property.name}:${state}`;
+  const defaultValue =
+    property.stateDefaults?.[state] ?? (state === "static" ? property.defaultValue : undefined);
+  const control = property.options
+    ? html`
+        <select name=${name} style="width: 100%; font-family: monospace;">
+          <option value="">-</option>
+          ${property.options.map(
+            (option) => html`
+              <option value=${option} ?selected=${option === defaultValue}>${option}</option>
+            `,
+          )}
+        </select>
+      `
+    : html`
+        <input
+          type="text"
+          name=${name}
+          list="box-model-tokens-${property.list}"
+          value=${defaultValue ?? ""}
+          style="width: 100%; font-family: monospace;"
+        />
+      `;
+  return html`
+    <div style="display: flex; flex-direction: column; gap: 0.125rem;">
+      ${control}
+      <code
+        data-token-display=${name}
+        data-property=${property.name}
+        data-category=${property.category}
+        data-state=${state}
+        style="font-size: 0.7rem; color: var(--usewc-color-document-text-muted); font-family: monospace; word-break: break-all;"
+      ></code>
+    </div>
+  `;
+}
+
+function renderGroup(
+  group: { caption: string; properties: ReadonlyArray<PlaygroundProperty> },
+  state: State,
+) {
+  return html`
+    <table width="100%">
+      <caption style="text-align: left; font-weight: bold; padding: 0.5rem 0;">
+        ${group.caption}
+      </caption>
+      <thead>
+        <tr>
+          <th width="25%" style="text-align: left;">Property</th>
+          <th style="text-align: left;">Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${group.properties.map(
+          (property) => html`
+            <tr>
+              <td><code>${property.name}</code></td>
+              <td>${renderControl(property, state)}</td>
+            </tr>
+          `,
+        )}
+      </tbody>
+    </table>
+  `;
+}
+
+function renderStateControls(state: State) {
+  return html`
+    <div style="display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; padding: 0.5rem 0;">
+      <label style="font-family: monospace;">
+        apply to
+        <select name=${`scope:${state}`}>
+          <option value="self">self (.box)</option>
+          <option value="parent">parent (.parent .box)</option>
+        </select>
+      </label>
+      ${STATE_ATTRIBUTES[state]
+        ? html`
+            <label style="font-family: monospace;">
+              <input type="checkbox" name=${`__preview-${state}`} value="on" />
+              preview this state on the sample
+            </label>
+          `
+        : ""}
+    </div>
+  `;
+}
+
+function renderStatePanel(state: State) {
+  return html`
+    <div data-state-panel=${state} ?hidden=${state !== "static"}>
+      ${state === "static" ? "" : renderStateControls(state)}
+      ${propertyGroups.map((group) => renderGroup(group, state))}
+    </div>
+  `;
+}
+
+function renderStateSelector() {
+  return html`
+    <div class="bmp-tablist">
+      ${STATES.map(
+        (state) => html`
+          <label class="bmp-tab">
+            <input type="radio" name="__state" value=${state} ?checked=${state === "static"} />
+            ${state}
+          </label>
+        `,
+      )}
+    </div>
+  `;
+}
+
+const meta: Meta = {
+  title: "Box Model Playground",
+  tags: ["autodocs", "!dev", "utility"],
+  args: {},
+  render: () => html`
+    <style>
+      .bmp-tablist {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+      }
+      .bmp-tab {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.25rem 0.6rem;
+        border: 1px solid var(--usewc-color-document-text-muted);
+        border-radius: 0.25rem;
+        cursor: pointer;
+        font-family: monospace;
+        font-size: 0.85rem;
+      }
+      .bmp-tab:has(input:checked) {
+        background: color-mix(in oklch, var(--usewc-color-outline) 18%, transparent);
+        border-color: var(--usewc-color-outline);
+        font-weight: bold;
+      }
+    </style>
+    <div style="display: flex; flex-direction: column; gap: 1.5rem; padding: 1rem;">
+      <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+        <div
+          class=${PARENT_CLASS}
+          tabindex="0"
+          style="display: flex; align-items: center; justify-content: center; min-height: 12rem; padding: 2rem; border: 1px dashed var(--usewc-color-document-text-muted);"
+        >
+          <div class=${BOX_CLASS} tabindex="0">
+            ${boxIcon("inline-start")} Sample box ${boxIcon("inline-end")}
+          </div>
+        </div>
+        <div
+          id=${DIMENSIONS_ID}
+          style="text-align: center; font-family: monospace; color: var(--usewc-color-document-text-muted);"
+        ></div>
+      </div>
+      <form ${ref(handleFormReady)} @change=${handleFormChange} @input=${handleFormInput}>
+        ${renderDatalists()}
+        <datalist id="box-model-components">
+          <option value="document"></option>
+          <option value="form"></option>
+          <option value="input"></option>
+          <option value="selector"></option>
+          <option value="action"></option>
+        </datalist>
+        <datalist id="box-model-parts">
+          <option value="trigger"></option>
+          <option value="segment"></option>
+          <option value="indicator"></option>
+          <option value="text"></option>
+          <option value="label"></option>
+          <option value="helper-text"></option>
+          <option value="header"></option>
+          <option value="body"></option>
+          <option value="aside"></option>
+          <option value="footer"></option>
+        </datalist>
+        <datalist id="box-model-variants">
+          <option value="base"></option>
+          <option value="primary"></option>
+          <option value="auxiliary"></option>
+          <option value="danger"></option>
+          <option value="attention"></option>
+          <option value="info"></option>
+          <option value="success"></option>
+        </datalist>
+        <datalist id="box-model-sizes">
+          <option value="extra-small"></option>
+          <option value="small"></option>
+          <option value="medium"></option>
+          <option value="large"></option>
+          <option value="extra-large"></option>
+        </datalist>
+        <div style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 0.75rem;">
+          <label style="display: flex; flex-direction: column; gap: 0.25rem;">
+            <strong>Component</strong>
+            <input
+              type="text"
+              name="__component"
+              list="box-model-components"
+              placeholder="action"
+              style="font-family: monospace; width: 100%;"
+            />
+          </label>
+          <label style="display: flex; flex-direction: column; gap: 0.25rem;">
+            <strong>Part</strong>
+            <input
+              type="text"
+              name="__part"
+              list="box-model-parts"
+              placeholder="(none)"
+              style="font-family: monospace; width: 100%;"
+            />
+          </label>
+          <label style="display: flex; flex-direction: column; gap: 0.25rem;">
+            <strong>Variant</strong>
+            <input
+              type="text"
+              name="__variant"
+              list="box-model-variants"
+              placeholder="base"
+              style="font-family: monospace; width: 100%;"
+            />
+          </label>
+          <label style="display: flex; flex-direction: column; gap: 0.25rem;">
+            <strong>Size</strong>
+            <input
+              type="text"
+              name="__size"
+              list="box-model-sizes"
+              placeholder="medium"
+              style="font-family: monospace; width: 100%;"
+            />
+          </label>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+          <strong>State</strong>
+          ${renderStateSelector()}
+        </div>
+        ${STATES.map((state) => renderStatePanel(state))}
+      </form>
+      <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+        <div style="display: flex; align-items: center; justify-content: space-between;">
+          <strong>Generated CSS</strong>
+          <button type="button" @click=${handleCopyToClipboard}>Copy to clipboard</button>
+        </div>
+        <pre
+          id=${GENERATED_ID}
+          style="font-family: monospace; padding: 1rem; background: var(--usewc-color-code-background); color: var(--usewc-color-code-text); border: 1px solid var(--usewc-color-code-border); border-radius: 0.25rem; white-space: pre-wrap; min-height: 4rem; margin: 0;"
+        >
+/* (no values yet) */</pre
+        >
+      </div>
+    </div>
+  `,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/native-elements.html
+++ b/src/stories/native-elements.html
@@ -27,7 +27,7 @@
   <input type="file" class="auxiliary" />
   <input type="file" class="primary" />
   <input type="file" class="danger" />
-  <input type="file" class="cancel" />
+  <input type="file" class="clear" />
   <input type="file" disabled />
   <input type="file" data-appear-as="native" />
   <use-field>
@@ -193,10 +193,10 @@
     <button type="button" class="danger">Danger</button>
     <button type="button" class="danger auxiliary">Danger auxiliary</button>
     <button type="button" class="danger" disabled>Danger disabled</button>
-    <h5>Cancel</h5>
-    <button type="button" class="cancel">Cancel</button>
-    <button type="button" class="cancel auxiliary">Cancel auxiliary</button>
-    <button type="button" class="cancel" disabled>Cancel disabled</button>
+    <h5>Clear</h5>
+    <button type="button" class="clear">Clear</button>
+    <button type="button" class="clear auxiliary">Clear auxiliary</button>
+    <button type="button" class="clear" disabled>Clear disabled</button>
     <h5>Unstyled</h5>
     <button type="button" data-appear-as="native">Native</button>
   </div>
@@ -210,8 +210,8 @@
   </div>
   <h4>As link</h4>
   <div>
-    <button type="button" class="cancel" data-appear-as="a">Button as Link</button>
-    <button type="button" class="cancel" data-appear-as="a">Button as Link disabled</button>
+    <button type="button" class="clear" data-appear-as="a">Button as Link</button>
+    <button type="button" class="clear" data-appear-as="a">Button as Link disabled</button>
   </div>
 </div>
 <h3>Details</h3>
@@ -231,7 +231,7 @@
     <a href="#" data-appear-as="button">Base button</a>
     <a href="#" data-appear-as="button" class="primary">Primary button</a>
     <a href="#" data-appear-as="button" class="danger">Danger button</a>
-    <a href="#" data-appear-as="button" class="cancel">Cancel button</a>
+    <a href="#" data-appear-as="button" class="clear">Clear button</a>
   </div>
   <h4>Unstyled</h4>
   <a href="#" data-appear-as="native">Native</a>

--- a/src/stories/theming-docs.css
+++ b/src/stories/theming-docs.css
@@ -4,5 +4,5 @@ body,
   color: var(--usewc-color-document-text) !important;
   background-color: var(--usewc-color-document-background) !important;
   font-family: var(--usewc-font-document-family) !important;
-  font-size: var(--usewc-layout-document-text-size) !important;
+  font-size: var(--usewc-font-document-size) !important;
 }

--- a/src/stories/token-name-builder.stories.ts
+++ b/src/stories/token-name-builder.stories.ts
@@ -121,7 +121,7 @@ const meta: Meta = {
                   <option>gap</option>
                   <option>size</option>
                   <option>line-height</option>
-                  <option>focus-ring</option>
+                  <option>outline</option>
                   <option>shadow</option>
                 </select>
               </td>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -322,21 +322,21 @@
       --usewc-theme-color-button-border-active: var(--usewc-color-button-danger-border-active);
     }
 
-    &.cancel {
-      --usewc-theme-color-button-text-static: var(--usewc-color-button-cancel-text-static);
-      --usewc-theme-color-button-text-static-auxiliary: var(--usewc-color-button-cancel-text-static-auxiliary);
-      --usewc-theme-color-button-background-static: var(--usewc-color-button-cancel-background-static);
+    &.clear {
+      --usewc-theme-color-button-text-static: var(--usewc-color-button-clear-text-static);
+      --usewc-theme-color-button-text-static-auxiliary: var(--usewc-color-button-clear-text-static-auxiliary);
+      --usewc-theme-color-button-background-static: var(--usewc-color-button-clear-background-static);
       --usewc-theme-color-button-background-static-auxiliary: var(
-        --usewc-color-button-cancel-background-static-auxiliary
+        --usewc-color-button-clear-background-static-auxiliary
       );
-      --usewc-theme-color-button-border-static: var(--usewc-color-button-cancel-border-static);
-      --usewc-theme-color-button-border-static-auxiliary: var(--usewc-color-button-cancel-border-static-auxiliary);
-      --usewc-theme-color-button-text-hover: var(--usewc-color-button-cancel-text-hover);
-      --usewc-theme-color-button-background-hover: var(--usewc-color-button-cancel-background-hover);
-      --usewc-theme-color-button-border-hover: var(--usewc-color-button-cancel-border-hover);
-      --usewc-theme-color-button-text-active: var(--usewc-color-button-cancel-text-active);
-      --usewc-theme-color-button-background-active: var(--usewc-color-button-cancel-background-active);
-      --usewc-theme-color-button-border-active: var(--usewc-color-button-cancel-border-active);
+      --usewc-theme-color-button-border-static: var(--usewc-color-button-clear-border-static);
+      --usewc-theme-color-button-border-static-auxiliary: var(--usewc-color-button-clear-border-static-auxiliary);
+      --usewc-theme-color-button-text-hover: var(--usewc-color-button-clear-text-hover);
+      --usewc-theme-color-button-background-hover: var(--usewc-color-button-clear-background-hover);
+      --usewc-theme-color-button-border-hover: var(--usewc-color-button-clear-border-hover);
+      --usewc-theme-color-button-text-active: var(--usewc-color-button-clear-text-active);
+      --usewc-theme-color-button-background-active: var(--usewc-color-button-clear-background-active);
+      --usewc-theme-color-button-border-active: var(--usewc-color-button-clear-border-active);
     }
 
     &.auxiliary:not(:is(:hover, :focus-visible, :active)) {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -11,7 +11,7 @@
     color: var(--usewc-color-document-text);
     background-color: var(--usewc-color-document-background);
     font-family: var(--usewc-font-document-family);
-    font-size: var(--usewc-layout-document-text-size);
+    font-size: var(--usewc-font-document-size);
   }
 
   :is(button, a, details summary, use-widget):not([data-appear-as="native"]):focus-visible,
@@ -60,7 +60,7 @@
     &:disabled,
     &[aria-disabled="true"],
     &:has(:disabled, [aria-disabled="true"]) {
-      opacity: var(--usewc-effect-control-opacity-disabled);
+      opacity: var(--usewc-effect-form-opacity-disabled);
       pointer-events: none;
     }
 
@@ -140,7 +140,7 @@
     }
 
     &:disabled {
-      opacity: var(--usewc-effect-control-opacity-disabled);
+      opacity: var(--usewc-effect-form-opacity-disabled);
       pointer-events: none;
     }
 
@@ -284,7 +284,7 @@
 
     &:disabled,
     &[aria-disabled="true"] {
-      opacity: var(--usewc-effect-control-opacity-disabled);
+      opacity: var(--usewc-effect-form-opacity-disabled);
       pointer-events: none;
     }
 
@@ -547,7 +547,7 @@
   }
 
   use-dropdown use-dropdown::part(trigger) {
-    background-image: var(--usewc-effect-dropdown-trigger-side-background-image);
+    background-image: var(--usewc-effect-dropdown-trigger-nested-background-image);
     background-position: right center;
   }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -19,9 +19,9 @@
   input[type="file"]:not([data-appear-as="native"]):focus-visible,
   use-dropdown:not([data-appear-as="native"])::part(trigger):focus-visible,
   [data-appear-as="input"]:has(input:focus) {
-    outline: var(--usewc-layout-focus-ring-size) var(--usewc-effect-focus-ring-style) var(--usewc-color-focus-ring);
-    outline-offset: var(--usewc-layout-focus-ring-offset-outside);
-    transition: var(--usewc-transition-focus-ring);
+    outline: var(--usewc-effect-outline-size) var(--usewc-effect-outline-style) var(--usewc-color-outline);
+    outline-offset: var(--usewc-effect-outline-offset);
+    transition: var(--usewc-effect-outline-transition);
   }
 
   :is(
@@ -54,7 +54,7 @@
 
     &:is(:focus, :has(input:focus), :focus-within) {
       border-color: var(--usewc-color-input-border-focus);
-      outline-offset: var(--usewc-layout-focus-ring-offset-inside);
+      outline-offset: var(--usewc-effect-outline-offset-flush);
     }
 
     &:disabled,
@@ -622,9 +622,9 @@
     &:focus-visible,
     &::part(trigger):focus-visible {
       background-color: var(--usewc-color-popover-menu-item-background-static);
-      outline: var(--usewc-layout-focus-ring-size) var(--usewc-effect-focus-ring-style) var(--usewc-color-focus-ring);
-      outline-offset: var(--usewc-layout-focus-ring-offset-inside);
-      transition: var(--usewc-transition-focus-ring);
+      outline: var(--usewc-effect-outline-size) var(--usewc-effect-outline-style) var(--usewc-color-outline);
+      outline-offset: var(--usewc-effect-outline-offset-flush);
+      transition: var(--usewc-effect-outline-transition);
       color: var(--usewc-color-popover-menu-item-text-focus);
     }
   }

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -13,13 +13,13 @@
   --usewc-font-input-family: inherit;
 
   /* Controls */
-  /* - Focus ring */
-  --usewc-color-focus-ring: var(--usewc-color-blue-500);
-  --usewc-layout-focus-ring-size: var(--usewc-space-2);
-  --usewc-layout-focus-ring-offset-outside: var(--usewc-space-2);
-  --usewc-layout-focus-ring-offset-inside: var(--usewc-space-none);
-  --usewc-effect-focus-ring-style: solid;
-  --usewc-transition-focus-ring: outline 0.05s ease-in-out;
+  /* - Outline (focus indicator) */
+  --usewc-color-outline: var(--usewc-color-blue-500);
+  --usewc-effect-outline-size: var(--usewc-space-2);
+  --usewc-effect-outline-offset: var(--usewc-space-2);
+  --usewc-effect-outline-offset-flush: var(--usewc-space-none);
+  --usewc-effect-outline-style: solid;
+  --usewc-effect-outline-transition: outline 0.05s ease-in-out;
   --usewc-effect-control-opacity-disabled: 0.5;
   /* - Link */
   --usewc-color-link-text-static: var(--usewc-color-blue-500);
@@ -246,7 +246,7 @@
     --usewc-color-document-text-muted: var(--usewc-color-gray-300);
     --usewc-color-document-background: var(--usewc-color-gray-800);
     --usewc-color-canvas-background: var(--usewc-color-black);
-    --usewc-color-focus-ring: var(--usewc-color-blue-200);
+    --usewc-color-outline: var(--usewc-color-blue-200);
     --usewc-color-input-background-static: oklch(from var(--usewc-color-gray-100) l c h / 0.025);
     --usewc-color-input-border-static: var(--usewc-color-gray-600);
     --usewc-color-input-text-static: var(--usewc-color-gray-200);

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -152,18 +152,18 @@
   --usewc-color-button-danger-text-static-auxiliary: var(--usewc-color-red-500);
   --usewc-color-button-danger-text-hover: var(--usewc-color-white);
   /* -- Cancel color */
-  --usewc-color-button-cancel-background-static: transaprent;
-  --usewc-color-button-cancel-background-static-auxiliary: transparent;
-  --usewc-color-button-cancel-background-hover: var(--usewc-color-gray-100);
-  --usewc-color-button-cancel-background-active: var(--usewc-color-gray-200);
-  --usewc-color-button-cancel-border-static: transparent;
-  --usewc-color-button-cancel-border-static-auxiliary: var(--usewc-color-gray-100);
-  --usewc-color-button-cancel-border-hover: transparent;
-  --usewc-color-button-cancel-border-active: transparent;
-  --usewc-color-button-cancel-text-static: var(--usewc-color-gray-700);
-  --usewc-color-button-cancel-text-static-auxiliary: var(--usewc-color-gray-700);
-  --usewc-color-button-cancel-text-hover: var(--usewc-color-gray-700);
-  --usewc-color-button-cancel-text-active: var(--usewc-color-gray-700);
+  --usewc-color-button-clear-background-static: transparent;
+  --usewc-color-button-clear-background-static-auxiliary: transparent;
+  --usewc-color-button-clear-background-hover: var(--usewc-color-gray-100);
+  --usewc-color-button-clear-background-active: var(--usewc-color-gray-200);
+  --usewc-color-button-clear-border-static: transparent;
+  --usewc-color-button-clear-border-static-auxiliary: var(--usewc-color-gray-100);
+  --usewc-color-button-clear-border-hover: transparent;
+  --usewc-color-button-clear-border-active: transparent;
+  --usewc-color-button-clear-text-static: var(--usewc-color-gray-700);
+  --usewc-color-button-clear-text-static-auxiliary: var(--usewc-color-gray-700);
+  --usewc-color-button-clear-text-hover: var(--usewc-color-gray-700);
+  --usewc-color-button-clear-text-active: var(--usewc-color-gray-700);
   /* - Layout */
   --usewc-layout-button-border: var(--usewc-space-1);
   --usewc-layout-button-background-size: calc(100% + var(--usewc-layout-button-border) * 2)
@@ -266,12 +266,12 @@
     --usewc-color-button-base-border-hover: var(--usewc-color-gray-500);
     --usewc-color-button-base-border-active: var(--usewc-color-gray-400);
     --usewc-color-button-base-border-static-auxiliary: var(--usewc-color-gray-600);
-    --usewc-color-button-cancel-text-static: var(--usewc-color-gray-200);
-    --usewc-color-button-cancel-text-hover: var(--usewc-color-gray-200);
-    --usewc-color-button-cancel-background-hover: var(--usewc-color-gray-700);
-    --usewc-color-button-cancel-border-hover: var(--usewc-color-gray-700);
-    --usewc-color-button-cancel-text-static-auxiliary: var(--usewc-color-gray-300);
-    --usewc-color-button-cancel-border-static-auxiliary: var(--usewc-color-gray-600);
+    --usewc-color-button-clear-text-static: var(--usewc-color-gray-200);
+    --usewc-color-button-clear-text-hover: var(--usewc-color-gray-200);
+    --usewc-color-button-clear-background-hover: var(--usewc-color-gray-700);
+    --usewc-color-button-clear-border-hover: var(--usewc-color-gray-700);
+    --usewc-color-button-clear-text-static-auxiliary: var(--usewc-color-gray-300);
+    --usewc-color-button-clear-border-static-auxiliary: var(--usewc-color-gray-600);
     --usewc-color-button-primary-background-static: var(--usewc-color-blue-400);
     --usewc-color-button-primary-background-hover: var(--usewc-color-blue-500);
     --usewc-color-button-primary-background-active: var(--usewc-color-blue-600);

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -1,6 +1,6 @@
 :root {
   /* Layout */
-  --usewc-layout-document-text-size: var(--usewc-font-size-16);
+  --usewc-font-document-size: var(--usewc-font-size-16);
   --usewc-color-document-text: var(--usewc-color-gray-700);
   --usewc-color-document-text-muted: var(--usewc-color-gray-500);
   --usewc-color-document-background: var(--usewc-color-white);
@@ -20,7 +20,7 @@
   --usewc-effect-outline-offset-flush: var(--usewc-space-none);
   --usewc-effect-outline-style: solid;
   --usewc-effect-outline-transition: outline 0.05s ease-in-out;
-  --usewc-effect-control-opacity-disabled: 0.5;
+  --usewc-effect-form-opacity-disabled: 0.5;
   /* - Link */
   --usewc-color-link-text-static: var(--usewc-color-blue-500);
   --usewc-color-link-text-hover: var(--usewc-color-blue-600);
@@ -28,7 +28,6 @@
   --usewc-color-link-text-visited: var(--usewc-color-indigo-500);
   --usewc-color-link-text-visited-hover: var(--usewc-color-indigo-600);
   --usewc-color-link-text-visited-active: var(--usewc-color-indigo-700);
-  --usewc-color-link-text-visited-visited: var(--usewc-color-indigo-500);
   --usewc-effect-link-text-decoration: underline;
 
   /* Form */
@@ -60,7 +59,7 @@
   --usewc-color-input-segment-background-focus: var(--usewc-color-blue-100);
   --usewc-color-input-segment-text-focus: var(--usewc-color-gray-700);
   --usewc-effect-dropdown-trigger-background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 16L5.0718 8.5L18.9282 8.5L12 16Z' fill='rgba(255,255,255,0.5' /%3E%3C/svg%3E");
-  --usewc-effect-dropdown-trigger-side-background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16 12L8.5 18.9282L8.5 5.0718Z' fill='rgba(255,255,255,0.5' /%3E%3C/svg%3E");
+  --usewc-effect-dropdown-trigger-nested-background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16 12L8.5 18.9282L8.5 5.0718Z' fill='rgba(255,255,255,0.5' /%3E%3C/svg%3E");
   --usewc-effect-dropdown-trigger-background-size: 1em;
   --usewc-effect-dropdown-trigger-background-blend-mode: difference;
   --usewc-effect-menu-item-checkmark-background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 13L10 18L19 7' stroke='rgba(255,255,255,0.5)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C%2Fsvg%3E");
@@ -76,7 +75,6 @@
   /* - Effect */
   --usewc-effect-input-border-style: solid;
   --usewc-effect-input-border-radius: var(--usewc-effect-border-radius-4);
-  --usewc-effect-input-opacity-disabled: 0.5;
   /* - Font */
   --usewc-font-input-size: var(--usewc-font-size-16);
 


### PR DESCRIPTION
## Summary

Adds a Storybook playground for exercising the design system's box-model and effect tokens against a live sample, and cleans up several token names that came up as confusing during the design work.

### What's in here

- **`feat(stories): box model playground`** — new story at \`src/stories/box-model-playground.stories.ts\`. Renders a sample box plus form controls for every layout/effect/animation property in scope, per interaction state (static / hover / focus / active / pressed / selected / checked / invalid / valid / disabled / readonly), with self-vs-parent scope toggles. Macro inputs (component / part / variant / size) emit a token-name suggestion below every control and remap the underlying \`--usewc-color-button-base-*\` and \`--usewc-layout-button-base-*\` tokens for variant/size respectively. Defaults populate from the design system's base button so the box renders as a real button on first load. Includes localStorage persistence and a generated-CSS readout with copy-to-clipboard.
- **`fix(tokens): button-cancel → button-clear`** — \`cancel\` was an action role that didn't sit alongside intent variants (base/primary/auxiliary/danger/...). \`clear\` describes both the action (clear input, clear form, close modal) and the visual treatment (transparent background, low chroma). Also fixes the \`transaprent\` typo on \`background-static\`, which was making that token resolve to an invalid color. Class hook \`&.cancel\` and consumer markup updated to match.
- **`refactor(tokens): focus-ring → outline\`** — six tokens renamed from \`focus-ring\` (design jargon) to \`outline\` (the actual CSS property they map to). The size/offset/style tokens also moved from \`layout-\` to \`effect-\` since outlines paint outside the box without reserving layout space. The misleading \`-offset-outside\` / \`-offset-inside\` pair (CSS only has one \`outline-offset\`) is replaced with \`-offset\` (default with a gap) and \`-offset-flush\` (zero gap, used by inputs whose own border serves as the visual edge).
- **`refactor(tokens): assorted cleanups`** — \`effect-control-opacity-disabled\` → \`effect-form-opacity-disabled\` (the \`control-\` prefix was ambiguous with the wider CSS sense); \`dropdown-trigger-side\` → \`dropdown-trigger-nested\` (the right-pointing chevron is for nested submenu triggers, not "side"); \`layout-document-text-size\` → \`font-document-size\` (it defines a font size, belongs in \`font-\`). Drops the unused \`color-link-text-visited-visited\` and \`effect-input-opacity-disabled\` duplicates.

### Why bundled

The renames came out of using the playground to validate the naming taxonomy — they're load-bearing for the playground reading sensibly (e.g. the playground references \`--usewc-color-outline\`). Splitting them out into separate PRs would have made each one read as an isolated nit; together they're a coherent cleanup pass.

### Behavioural impact

- **CSS consumers using \`class=\"cancel\"\`** must update to \`class=\"clear\"\`. \`native-elements.html\` is updated.
- **Token consumers** referencing any renamed token must update. Six \`focus-ring\` tokens, the cancel-variant family, and the four miscellaneous renames listed above.
- The sample button on the playground story now renders as the real base button on first load (was an unstyled box previously).

## Test plan

- [ ] \`vp check\` and \`vp test\` pass
- [ ] Storybook renders the new \"Box Model Playground\" story under its top-level title; the sample box renders as a base button by default
- [ ] Picking variant=\`primary\` swaps the box to the primary palette; picking size=\`large\` resizes it; the per-state preview checkbox applies the corresponding aria attribute
- [ ] Inspecting any input shows a live token-name suggestion below it that updates as Component / Part / Variant change
- [ ] In Storybook's \"Native Elements\" story, the four \"Clear\" buttons render with the correct (transparent + gray hover) treatment
- [ ] Keyboard focus on any input/button still shows the outline (verifies the focus-ring → outline rename works end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)