### PR TITLE
feat(theme): theme segmented controls (date, time, datetime, duration)

### DIFF
--- a/src/elements/use-date-input/use-date-input.test.ts
+++ b/src/elements/use-date-input/use-date-input.test.ts
@@ -1,0 +1,68 @@
+import { expect, describe, it } from "vite-plus/test";
+import { render } from "vitest-browser-lit";
+import { html } from "lit";
+import "./use-date-input";
+import { UseDateInput } from "./use-date-input";
+
+describe("use-date-input", () => {
+  function getDateInput() {
+    return document.querySelector("use-date-input") as UseDateInput;
+  }
+
+  function getSegmentInput(dateInput: UseDateInput, segment: string) {
+    return dateInput.shadowRoot!.querySelector(
+      `input[part~="segment-input-${segment}"]`,
+    ) as HTMLInputElement;
+  }
+
+  function simulateInput(input: HTMLInputElement, value: string) {
+    input.value = value;
+    input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+  }
+
+  describe("segment clamping", () => {
+    it("clamps month value to 12 when a higher value is typed", async () => {
+      render(html`<use-date-input></use-date-input>`);
+      const dateInput = getDateInput();
+      await dateInput.updateComplete;
+
+      const monthInput = getSegmentInput(dateInput, "month");
+      simulateInput(monthInput, "99");
+
+      expect(monthInput.value).toBe("12");
+    });
+
+    it("clamps day value to 31 when a higher value is typed", async () => {
+      render(html`<use-date-input></use-date-input>`);
+      const dateInput = getDateInput();
+      await dateInput.updateComplete;
+
+      const dayInput = getSegmentInput(dateInput, "day");
+      simulateInput(dayInput, "99");
+
+      expect(dayInput.value).toBe("31");
+    });
+
+    it("allows year values greater than 31", async () => {
+      render(html`<use-date-input></use-date-input>`);
+      const dateInput = getDateInput();
+      await dateInput.updateComplete;
+
+      const yearInput = getSegmentInput(dateInput, "year");
+      simulateInput(yearInput, "2099");
+
+      expect(yearInput.value).toBe("2099");
+    });
+
+    it("does not clamp valid month values", async () => {
+      render(html`<use-date-input></use-date-input>`);
+      const dateInput = getDateInput();
+      await dateInput.updateComplete;
+
+      const monthInput = getSegmentInput(dateInput, "month");
+      simulateInput(monthInput, "6");
+
+      expect(monthInput.value).toBe("6");
+    });
+  });
+});

--- a/src/elements/use-date-input/use-date-input.ts
+++ b/src/elements/use-date-input/use-date-input.ts
@@ -107,9 +107,20 @@ export class UseDateInput extends UseLocaleElement {
     this.#internals.setFormValue(this.#internalValue);
   }
 
+  #segmentMaximum: Record<DateSegment, number | null> = {
+    year: null,
+    month: 12,
+    day: 31,
+  };
+
   #handleSegmentInput(segment: DateSegment) {
     return (event: Event) => {
       const target = event.target as HTMLInputElement;
+      const maximum = this.#segmentMaximum[segment];
+      const numericValue = parseInt(target.value, 10);
+      if (maximum !== null && !isNaN(numericValue) && numericValue > maximum) {
+        target.value = String(maximum);
+      }
       this.#valueData[segment] = target.value;
       this.#updateInternalValue();
     };

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -477,6 +477,13 @@
 }
 
 @layer web-components {
+  /* Composite segmented controls */
+  use-datetime-input:not([data-appear-as="native"]) {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--usewc-layout-input-gap-inline);
+  }
+
   /* Segment based controls */
   :is(use-date-input, use-time-input):not([data-appear-as="native"]) {
     display: inline-flex;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -15,7 +15,7 @@
   }
 
   :is(button, a, details summary, use-widget):not([data-appear-as="native"]):focus-visible,
-  :is(input, textarea, select, use-date-input, use-time-input):not([data-appear-as="native"]):focus,
+  :is(input, textarea, select, use-date-input, use-time-input, use-datetime-input):not([data-appear-as="native"]):focus,
   input[type="file"]:not([data-appear-as="native"]):focus-visible,
   use-dropdown:not([data-appear-as="native"])::part(trigger):focus-visible,
   [data-appear-as="input"]:has(input:focus) {
@@ -30,7 +30,8 @@
     textarea,
     [data-appear-as="input"],
     use-date-input,
-    use-time-input
+    use-time-input,
+    use-datetime-input
   ):not([data-appear-as="native"]),
   use-listbox-input:not([data-appear-as="native"])::part(listbox) {
     border: var(--usewc-layout-input-border) var(--usewc-effect-input-border-style)
@@ -477,6 +478,56 @@
 }
 
 @layer web-components {
+  /* Composite datetime control — host gets the single input wrapper appearance via the main
+     input styling block. The date and time sub-inputs live in shadow DOM and are reached via
+     ::part(date) and ::part(time) to override their internal layout. Segment inputs are
+     re-exported via exportparts so ::part(segment-input) reaches them too. */
+  use-datetime-input:not([data-appear-as="native"]) {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    gap: var(--usewc-layout-input-gap-inline);
+    padding-inline: calc(var(--usewc-layout-input-padding-inline) - var(--usewc-layout-input-segment-padding-inline));
+
+    &::part(date),
+    &::part(time) {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--usewc-layout-input-segment-padding-inline);
+    }
+
+    &::part(segment-input) {
+      all: unset;
+      box-sizing: content-box;
+      appearance: none;
+      field-sizing: content;
+      background: var(--usewc-color-input-segment-background-static);
+      outline: none;
+      border-radius: var(--usewc-effect-input-border-radius);
+      min-width: 2ch;
+      width: fit-content;
+      text-align: end;
+      padding-inline: var(--usewc-layout-input-segment-padding-inline);
+      font-variant-numeric: tabular-nums;
+    }
+
+    &::part(segment-input-dayPeriod) {
+      text-align: center;
+      min-width: 2em;
+      padding-inline: 0;
+    }
+
+    &::part(segment-input):hover {
+      background: var(--usewc-color-input-segment-background-hover);
+    }
+
+    &::part(segment-input):focus,
+    &::selection {
+      background: var(--usewc-color-input-segment-background-focus);
+      color: var(--usewc-color-input-segment-text-focus);
+    }
+  }
+
   /* Segment based controls */
   :is(use-date-input, use-time-input):not([data-appear-as="native"]) {
     display: inline-flex;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -15,7 +15,7 @@
   }
 
   :is(button, a, details summary, use-widget):not([data-appear-as="native"]):focus-visible,
-  :is(input, textarea, select, use-date, use-time, use-datetime, use-duration):not([data-appear-as="native"]):focus,
+  :is(input, textarea, select, use-date-input):not([data-appear-as="native"]):focus,
   input[type="file"]:not([data-appear-as="native"]):focus-visible,
   use-dropdown:not([data-appear-as="native"])::part(trigger):focus-visible,
   [data-appear-as="input"]:has(input:focus) {
@@ -26,14 +26,11 @@
 
   :is(
     input:not(:is([type="checkbox"], [type="radio"], [type="range"], [type="file"], [data-appear-as])),
-    select:not([data-appear-as="native"]),
+    select,
     textarea,
     [data-appear-as="input"],
-    use-date:not([data-appear-as="native"]),
-    use-time:not([data-appear-as="native"]),
-    use-datetime:not([data-appear-as="native"]),
-    use-duration:not([data-appear-as="native"])
-  ),
+    use-date-input
+  ):not([data-appear-as="native"]),
   use-listbox-input:not([data-appear-as="native"])::part(listbox) {
     border: var(--usewc-layout-input-border) var(--usewc-effect-input-border-style)
       var(--usewc-color-input-border-static);
@@ -480,9 +477,7 @@
 
 @layer web-components {
   /* Segment based controls */
-  :is(use-date, use-time, use-datetime, use-duration):not([data-appear-as="native"]),
-  use-datetime::part(date),
-  use-datetime::part(time) {
+  :is(use-date-input):not([data-appear-as="native"]) {
     display: inline-flex;
     align-items: center;
     width: fit-content;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -15,7 +15,7 @@
   }
 
   :is(button, a, details summary, use-widget):not([data-appear-as="native"]):focus-visible,
-  :is(input, textarea, select, use-date-input):not([data-appear-as="native"]):focus,
+  :is(input, textarea, select, use-date-input, use-time-input):not([data-appear-as="native"]):focus,
   input[type="file"]:not([data-appear-as="native"]):focus-visible,
   use-dropdown:not([data-appear-as="native"])::part(trigger):focus-visible,
   [data-appear-as="input"]:has(input:focus) {
@@ -29,7 +29,8 @@
     select,
     textarea,
     [data-appear-as="input"],
-    use-date-input
+    use-date-input,
+    use-time-input
   ):not([data-appear-as="native"]),
   use-listbox-input:not([data-appear-as="native"])::part(listbox) {
     border: var(--usewc-layout-input-border) var(--usewc-effect-input-border-style)
@@ -477,7 +478,7 @@
 
 @layer web-components {
   /* Segment based controls */
-  :is(use-date-input):not([data-appear-as="native"]) {
+  :is(use-date-input, use-time-input):not([data-appear-as="native"]) {
     display: inline-flex;
     align-items: center;
     width: fit-content;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -477,13 +477,6 @@
 }
 
 @layer web-components {
-  /* Composite segmented controls */
-  use-datetime-input:not([data-appear-as="native"]) {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--usewc-layout-input-gap-inline);
-  }
-
   /* Segment based controls */
   :is(use-date-input, use-time-input):not([data-appear-as="native"]) {
     display: inline-flex;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -15,7 +15,9 @@
   }
 
   :is(button, a, details summary, use-widget):not([data-appear-as="native"]):focus-visible,
-  :is(input, textarea, select, use-date-input, use-time-input, use-datetime-input):not([data-appear-as="native"]):focus,
+  :is(input, textarea, select, use-date-input, use-time-input, use-datetime-input, use-duration-input):not(
+      [data-appear-as="native"]
+    ):focus,
   input[type="file"]:not([data-appear-as="native"]):focus-visible,
   use-dropdown:not([data-appear-as="native"])::part(trigger):focus-visible,
   [data-appear-as="input"]:has(input:focus) {
@@ -31,7 +33,8 @@
     [data-appear-as="input"],
     use-date-input,
     use-time-input,
-    use-datetime-input
+    use-datetime-input,
+    use-duration-input
   ):not([data-appear-as="native"]),
   use-listbox-input:not([data-appear-as="native"])::part(listbox) {
     border: var(--usewc-layout-input-border) var(--usewc-effect-input-border-style)
@@ -568,16 +571,42 @@
     }
   }
 
-  :is(use-datetime, use-duration):not([data-appear-as="native"]) {
+  use-duration-input:not([data-appear-as="native"]) {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
     gap: var(--usewc-layout-input-gap-inline);
-  }
-
-  use-duration:not([data-appear-as="native"]) {
-    padding-inline-end: var(--usewc-layout-input-padding-inline);
+    padding-inline: calc(var(--usewc-layout-input-padding-inline) - var(--usewc-layout-input-segment-padding-inline));
 
     &::part(segment) {
       display: inline-flex;
+      align-items: center;
       gap: var(--usewc-layout-input-segment-padding-inline);
+    }
+
+    &::part(segment-input) {
+      all: unset;
+      box-sizing: content-box;
+      appearance: none;
+      field-sizing: content;
+      background: var(--usewc-color-input-segment-background-static);
+      outline: none;
+      border-radius: var(--usewc-effect-input-border-radius);
+      min-width: 2ch;
+      width: fit-content;
+      text-align: end;
+      padding-inline: var(--usewc-layout-input-segment-padding-inline);
+      font-variant-numeric: tabular-nums;
+    }
+
+    &::part(segment-input):hover {
+      background: var(--usewc-color-input-segment-background-hover);
+    }
+
+    &::part(segment-input):focus,
+    &::selection {
+      background: var(--usewc-color-input-segment-background-focus);
+      color: var(--usewc-color-input-segment-text-focus);
     }
   }
 


### PR DESCRIPTION
## Summary

Wires the four segmented input components into the token-based theming system:

- **use-date-input** — single bordered input wrapper, segments with hover/focus highlights
- **use-time-input** — same treatment, with the dayPeriod (AM/PM) segment centered
- **use-datetime-input** — composite that wraps `use-date-input` and `use-time-input` in shadow DOM; styled as a single unified input via `::part(date)`, `::part(time)`, and the re-exported `::part(segment-input)` (light-DOM selectors can't reach the inner custom elements directly)
- **use-duration-input** — handles the `<input>` + unit label per segment (e.g. \"1 hr 30 min\") via `::part(segment)` and `::part(segment-input)`

The previous theme.css selectors targeted `use-date`, `use-time`, `use-datetime`, and `use-duration` — names that didn't match any registered custom element, so the rules never applied. The selectors are also simplified by hoisting \`:not([data-appear-as=\"native\"])\` outside the \`:is()\` instead of repeating it on every entry.

Also fixes an unrelated bug in **use-date-input** where typing more digits than allowed (e.g. \`1234\` in the month field) wasn't clamped. The \`max\` attribute on \`input[type=number]\` only affects form validation, not typed input. Added a \`#segmentMaximum\` map and a clamping step in the input handler, plus tests.

## Changes

- \`src/styles/theme.css\` — new selectors for all four segmented components, removing stale names
- \`src/elements/use-date-input/use-date-input.ts\` — clamp segment values on input
- \`src/elements/use-date-input/use-date-input.test.ts\` — new tests for clamping

## Test plan

- [x] \`vp test\` — 89 passing (4 new clamping tests)
- [x] \`vp check\` — format + lint pass
- [ ] Visually verify all four components in Storybook (use-date-input, use-time-input, use-datetime-input, use-duration-input)
- [ ] Confirm focus ring fires on outer host when any segment is focused
- [ ] Confirm hover/focus highlights work on individual segments
- [ ] Confirm typing 99 in the month field clamps to 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)