### PR TITLE
refactor(theme): migrate `data-appear-as` to `.appearance-*` classes

### DIFF
--- a/src/stories/native-elements.html
+++ b/src/stories/native-elements.html
@@ -29,7 +29,7 @@
   <input type="file" class="danger" />
   <input type="file" class="clear" />
   <input type="file" disabled />
-  <input type="file" data-appear-as="native" />
+  <input type="file" class="appearance-native" />
   <use-field>
     <label for="file-field">File Field</label>
     <input type="file" id="file-field" placeholder="Enter your file" />
@@ -37,8 +37,8 @@
   </use-field>
 
   <h4>Unstyled</h4>
-  <p>You can escape from the theme styles by adding the <code>data-appear-as="native"</code> attribute.</p>
-  <input type="text" placeholder="Enter your name" data-appear-as="native" />
+  <p>You can escape from the theme styles by adding the <code>class="appearance-native"</code> class.</p>
+  <input type="text" placeholder="Enter your name" class="appearance-native" />
   <p>You can escape from the theme styles by wrapping the UI in a <code>use-theme-escape</code> element.</p>
   <use-theme-escape>
     <input type="text" class="primary auxiliary" />
@@ -65,7 +65,7 @@
   <h3>As input</h3>
   <use-field>
     <label for="as-input-field">As input field</label>
-    <div data-appear-as="input">
+    <div class="appearance-input">
       <span>Prefix</span>
       <input id="as-input-field" placeholder="embedded input" />
       <span>Suffix</span>
@@ -73,7 +73,7 @@
   </use-field>
   <use-field>
     <label for="as-input-field-2">As input field 2</label>
-    <div data-appear-as="input">
+    <div class="appearance-input">
       <span>Prefix</span>
       <input id="as-input-field-2" placeholder="embedded input" disabled />
       <span>Suffix</span>
@@ -81,7 +81,7 @@
   </use-field>
   <use-field>
     <label for="as-input-field-3">As input field 3</label>
-    <div data-appear-as="input">
+    <div class="appearance-input">
       <button type="button" class="small">Button</button>
       <input id="as-input-field-3" placeholder="embedded input" />
       <button type="button" class="small">Button</button>
@@ -105,7 +105,7 @@
   <option value="2">Option 2</option>
   <option value="3">Option 3</option>
 </select>
-<select data-appear-as="native">
+<select class="appearance-native">
   <option value="1">Native select</option>
 </select>
 
@@ -128,7 +128,7 @@
 </use-field>
 <use-field>
   <label for="range-native">Native</label>
-  <input type="range" id="range-native" data-appear-as="native" />
+  <input type="range" id="range-native" class="appearance-native" />
 </use-field>
 
 <h3>Checkbox</h3>
@@ -198,7 +198,7 @@
     <button type="button" class="clear auxiliary">Clear auxiliary</button>
     <button type="button" class="clear" disabled>Clear disabled</button>
     <h5>Unstyled</h5>
-    <button type="button" data-appear-as="native">Native</button>
+    <button type="button" class="appearance-native">Native</button>
   </div>
   <h4>Sizes</h4>
   <div style="display: flex; gap: 0.5rem; align-items: center">
@@ -210,8 +210,8 @@
   </div>
   <h4>As link</h4>
   <div>
-    <button type="button" class="clear" data-appear-as="a">Button as Link</button>
-    <button type="button" class="clear" data-appear-as="a">Button as Link disabled</button>
+    <button type="button" class="clear appearance-a">Button as Link</button>
+    <button type="button" class="clear appearance-a">Button as Link disabled</button>
   </div>
 </div>
 <h3>Details</h3>
@@ -220,7 +220,7 @@
   <p>This is a details content</p>
 </details>
 <details>
-  <summary data-appear-as="button">As button</summary>
+  <summary class="appearance-button">As button</summary>
   <p>This is a details content</p>
 </details>
 <h3>Link</h3>
@@ -228,11 +228,11 @@
   <a href="#">Link</a>
   <h4>As button</h4>
   <div style="display: flex; gap: 0.5rem; align-items: center">
-    <a href="#" data-appear-as="button">Base button</a>
-    <a href="#" data-appear-as="button" class="primary">Primary button</a>
-    <a href="#" data-appear-as="button" class="danger">Danger button</a>
-    <a href="#" data-appear-as="button" class="clear">Clear button</a>
+    <a href="#" class="appearance-button">Base button</a>
+    <a href="#" class="appearance-button primary">Primary button</a>
+    <a href="#" class="appearance-button danger">Danger button</a>
+    <a href="#" class="appearance-button clear">Clear button</a>
   </div>
   <h4>Unstyled</h4>
-  <a href="#" data-appear-as="native">Native</a>
+  <a href="#" class="appearance-native">Native</a>
 </div>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -14,29 +14,29 @@
     font-size: var(--usewc-font-document-size);
   }
 
-  :is(button, a, details summary, use-widget):not([data-appear-as="native"]):focus-visible,
+  :is(button, a, details summary, use-widget):not(.appearance-native):focus-visible,
   :is(input, textarea, select, use-date-input, use-time-input, use-datetime-input, use-duration-input):not(
-      [data-appear-as="native"]
+      .appearance-native
     ):focus,
-  input[type="file"]:not([data-appear-as="native"]):focus-visible,
-  use-dropdown:not([data-appear-as="native"])::part(trigger):focus-visible,
-  [data-appear-as="input"]:has(input:focus) {
+  input[type="file"]:not(.appearance-native):focus-visible,
+  use-dropdown:not(.appearance-native)::part(trigger):focus-visible,
+  .appearance-input:has(input:focus) {
     outline: var(--usewc-effect-outline-size) var(--usewc-effect-outline-style) var(--usewc-color-outline);
     outline-offset: var(--usewc-effect-outline-offset);
     transition: var(--usewc-effect-outline-transition);
   }
 
   :is(
-    input:not(:is([type="checkbox"], [type="radio"], [type="range"], [type="file"], [data-appear-as])),
+    input:not(:is([type="checkbox"], [type="radio"], [type="range"], [type="file"], [class*="appearance-"])),
     select,
     textarea,
-    [data-appear-as="input"],
+    .appearance-input,
     use-date-input,
     use-time-input,
     use-datetime-input,
     use-duration-input
-  ):not([data-appear-as="native"]),
-  use-listbox-input:not([data-appear-as="native"])::part(listbox) {
+  ):not(.appearance-native),
+  use-listbox-input:not(.appearance-native)::part(listbox) {
     border: var(--usewc-layout-input-border) var(--usewc-effect-input-border-style)
       var(--usewc-color-input-border-static);
     line-height: var(--usewc-layout-input-line-height);
@@ -49,7 +49,7 @@
     color: var(--usewc-color-input-text-static);
     border-radius: var(--usewc-effect-input-border-radius);
 
-    &:not(:is(:disabled, [aria-disabled="true"], [data-appear-as="input"])):hover,
+    &:not(:is(:disabled, [aria-disabled="true"], .appearance-input)):hover,
     &:has(input:not(:is(:disabled, [aria-disabled="true"])):hover) {
       border-color: var(--usewc-color-input-border-hover);
     }
@@ -75,15 +75,15 @@
     }
   }
 
-  use-listbox-input:not([data-appear-as="native"])::part(listbox) {
+  use-listbox-input:not(.appearance-native)::part(listbox) {
     padding: var(--usewc-layout-popover-menu-padding);
   }
 
-  select:not([data-appear-as="native"]) {
+  select:not(.appearance-native) {
     appearance: none;
   }
 
-  [data-appear-as="input"] {
+  .appearance-input {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -190,11 +190,11 @@
    * - https://codepen.io/ShadowShahriar/pen/zYPPYrQ
    * - https://open-ui.org/components/enhanced-range-input.explainer/
    */
-  input[type="range"]:not([data-appear-as="native"]) {
+  input[type="range"]:not(.appearance-native) {
     accent-color: var(--usewc-color-range-thumb-background-static);
   }
 
-  :is(a:not([data-appear-as]), [data-appear-as="a"]) {
+  :is(a:not([class*="appearance-"]), .appearance-a) {
     &:where(:not(a)) {
       all: unset;
     }
@@ -212,9 +212,9 @@
     }
   }
 
-  :is(button:not([data-appear-as]), [data-appear-as="button"]),
+  :is(button:not([class*="appearance-"]), .appearance-button),
   use-dropdown,
-  input[type="file"]:not([data-appear-as]) {
+  input[type="file"]:not([class*="appearance-"]) {
     &:where(:not(button)),
     &::file-selector-button {
       all: unset;
@@ -376,12 +376,12 @@
     }
   }
 
-  input[type="file"]:not([data-appear-as]) {
+  input[type="file"]:not([class*="appearance-"]) {
     border-radius: var(--usewc-effect-input-border-radius);
   }
 
   code,
-  [data-appear-as="code"] {
+  .appearance-code {
     display: inline-block;
     font-family: var(--usewc-font-code-family);
     font-size: var(--usewc-font-code-size);
@@ -453,7 +453,7 @@
     }
   }
 
-  details:not([data-appear-as="native"]) {
+  details:not(.appearance-native) {
     summary {
       all: unset;
 
@@ -485,7 +485,7 @@
      input styling block. The date and time sub-inputs live in shadow DOM and are reached via
      ::part(date) and ::part(time) to override their internal layout. Segment inputs are
      re-exported via exportparts so ::part(segment-input) reaches them too. */
-  use-datetime-input:not([data-appear-as="native"]) {
+  use-datetime-input:not(.appearance-native) {
     display: inline-flex;
     align-items: center;
     width: fit-content;
@@ -532,7 +532,7 @@
   }
 
   /* Segment based controls */
-  :is(use-date-input, use-time-input):not([data-appear-as="native"]) {
+  :is(use-date-input, use-time-input):not(.appearance-native) {
     display: inline-flex;
     align-items: center;
     width: fit-content;
@@ -571,7 +571,7 @@
     }
   }
 
-  use-duration-input:not([data-appear-as="native"]) {
+  use-duration-input:not(.appearance-native) {
     display: inline-flex;
     align-items: center;
     width: fit-content;
@@ -610,7 +610,7 @@
     }
   }
 
-  select:not([data-appear-as="native"]),
+  select:not(.appearance-native),
   use-dropdown::part(trigger),
   use-dropdown use-dropdown::part(trigger) {
     padding-inline-end: calc(var(--usewc-layout-input-padding-inline) * 2 + var(--usewc-layout-selector-width));
@@ -627,7 +627,7 @@
     background-position: right center;
   }
 
-  select:not([data-appear-as="native"]),
+  select:not(.appearance-native),
   use-dropdown::part(trigger),
   use-dropdown use-dropdown::part(trigger) {
     anchor-name: --use-popover-trigger;


### PR DESCRIPTION
## Summary

- Replace the `data-appear-as` data attribute API with class-based equivalents for consistency with the theme's other modifier conventions (`.primary`, `.danger`, `.clear`, etc.).
- Bare `[data-appear-as]` selectors used as "any appearance override" markers inside `:not(...)` become `[class*="appearance-"]`, preserving the single-selector "has any" semantics without enumerating values.

## Mapping

| Before | After |
| --- | --- |
| `[data-appear-as="native"]` | `.appearance-native` |
| `[data-appear-as="input"]` | `.appearance-input` |
| `[data-appear-as="a"]` | `.appearance-a` |
| `[data-appear-as="button"]` | `.appearance-button` |
| `[data-appear-as="code"]` | `.appearance-code` |
| `[data-appear-as]` (bare) | `[class*="appearance-"]` |

## Files changed

- `src/styles/theme.css` — all selectors migrated
- `src/stories/native-elements.html` — story updated to use the new class API; inline docs prose updated to reference `class="appearance-native"`

## Notes for reviewers

- **Behavior is intended to be identical.** Class and attribute selectors have the same specificity (`0,1,0`), and `[class*="appearance-"]` matches any of the new class values.
- **Performance:** the substring attribute selector only appears inside `:not(...)` qualifying tag selectors (`input`, `a`, `button`), so the candidate set is already narrowed by tag before the substring check runs. No measurable impact.
- **Breaking change for consumers** using the old `data-appear-as="..."` attribute. They'll need to switch to the new class names. Worth a note in the changelog/release.

## Test plan

- [x] `vp check` (format + lint + types) passes
- [x] `vp test` passes (89 tests)
- [x] No remaining `data-appear-as` references in `src/`
- [ ] Visual spot-check in Storybook's `native-elements` story:
  - [ ] Elements with `.appearance-native` render with default browser styling
  - [ ] `<a class="appearance-button">`, `<summary class="appearance-button">` adopt button appearance
  - [ ] `<button class="clear appearance-a">` adopts link appearance
  - [ ] `<div class="appearance-input">` group renders as input wrapper with focus-within highlighting
  - [ ] `.appearance-code` styling still applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)